### PR TITLE
Make filterable dropdown search accent-insensitive

### DIFF
--- a/src/Meziantou.Moneiz/Shared/InputSelectFilterable.razor
+++ b/src/Meziantou.Moneiz/Shared/InputSelectFilterable.razor
@@ -176,12 +176,15 @@
             return;
         }
 
-        var searchTerms = searchText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var searchTerms = searchText
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Select(static term => term.RemoveDiacritics())
+            .ToArray();
 
         _filteredItems = Items
             .Where(item =>
             {
-                var searchableText = GetSearchableText(item);
+                var searchableText = GetSearchableText(item).RemoveDiacritics();
                 return searchTerms.All(term => searchableText.Contains(term, StringComparison.OrdinalIgnoreCase));
             })
             .OrderBy(GetGroupName)


### PR DESCRIPTION
## Why
The custom dropdown search required exact accents, so users typing plain text like `vetement` could not find entries such as `Vêtement`.

## What changed
- Updated `InputSelectFilterable` filtering to remove diacritics from both search terms and each item's searchable text before matching.
- Kept existing behavior unchanged otherwise: terms are still split on spaces, all terms must match, and ordering/grouping stays the same.
- Reused existing `RemoveDiacritics()` behavior already used elsewhere in the project for consistency.

## Notes for reviewers
This is intentionally scoped to matching logic only; UI behavior and selection mechanics are unchanged.

## Validation
- `dotnet test tests/Meziantou.Moneiz.CoreTests/Meziantou.Moneiz.CoreTests.csproj` (passes)
- Full WASM project build is blocked in this environment because `wasm-tools` workload restore requires elevated permissions.