### PR TITLE
Upgrade tests to xUnit v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.8" />
     <PackageVersion Include="System.CommandLine" Version="2.0.8" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/tests/Meziantou.Moneiz.CoreTests/Meziantou.Moneiz.CoreTests.csproj
+++ b/tests/Meziantou.Moneiz.CoreTests/Meziantou.Moneiz.CoreTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <ItemGroup>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Why
The test project was still using the `xunit` package reference. This change aligns the repository with xUnit v3 package naming and versioning.

## What changed
- Replaced the central package version entry from `xunit` to `xunit.v3` in `Directory.Packages.props`
- Updated `Meziantou.Moneiz.CoreTests.csproj` to reference `xunit.v3`
- Kept `xunit.runner.visualstudio` as-is