### PR TITLE
Trap Enter in payee input when a suggestion is active

### DIFF
--- a/src/Meziantou.Moneiz/Shared/InputPayee.razor
+++ b/src/Meziantou.Moneiz/Shared/InputPayee.razor
@@ -1,8 +1,11 @@
 @inherits InputBase<string?>
+@implements IAsyncDisposable
 @inject DatabaseProvider DatabaseProvider
+@inject IJSRuntime JSRuntime
 
 <div class="input-payee @(_isOpen ? "is-open" : "")">
     <input type="text"
+           @ref="_input"
            class="@CssClass"
            value="@CurrentValueAsString"
            autocomplete="off"
@@ -50,6 +53,7 @@
     private const int MaximumSuggestionCount = 10;
     private readonly string _listId = "input-payee-" + Guid.NewGuid().ToString("N");
     private Database? _database;
+    private ElementReference _input;
     private IReadOnlyList<Payee> _suggestions = [];
     private bool _isOpen;
     private bool _hasTypedSinceFocus;
@@ -79,6 +83,25 @@
         result = value;
         validationErrorMessage = null;
         return true;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await JSRuntime.InvokeVoidAsync("MoneizTrapEnterKey", _input);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        try
+        {
+            await JSRuntime.InvokeVoidAsync("MoneizReleaseTrapEnterKey", _input);
+        }
+        catch (JSDisconnectedException)
+        {
+        }
     }
 
     private void Open()

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -37,6 +37,29 @@ async function MoneizUpdate() {
   location.reload(true);
 }
 
+function MoneizTrapEnterKey(element) {
+  if (!element || element.moneizTrapEnterKey) {
+    return;
+  }
+
+  element.moneizTrapEnterKey = function (event) {
+    if (event.key === "Enter" && element.getAttribute("aria-expanded") === "true" && element.getAttribute("aria-activedescendant")) {
+      event.preventDefault();
+    }
+  };
+
+  element.addEventListener("keydown", element.moneizTrapEnterKey);
+}
+
+function MoneizReleaseTrapEnterKey(element) {
+  if (!element || !element.moneizTrapEnterKey) {
+    return;
+  }
+
+  element.removeEventListener("keydown", element.moneizTrapEnterKey);
+  delete element.moneizTrapEnterKey;
+}
+
 (function () {
   let state = false;
 


### PR DESCRIPTION
## Summary
- Prevent Enter from submitting the form while the payee autocomplete is open and a suggestion is selected.
- Add a small JS interop helper to attach and clean up the keydown trap on the input element.
- Dispose the Blazor component cleanly and release the event listener on teardown.

## Testing
- Not run (not requested)