### PR TITLE
Use service worker state for PWA update detection

### DIFF
--- a/src/Meziantou.Moneiz/Services/GlobalInterop.cs
+++ b/src/Meziantou.Moneiz/Services/GlobalInterop.cs
@@ -24,6 +24,9 @@ public static partial class GlobalInterop
     [JSImport("globalThis.MoneizGetValue")]
     public static partial Task<string> GetValue(string name);
 
+    [JSImport("globalThis.MoneizHasUpdateAvailable")]
+    public static partial Task<bool> HasUpdateAvailable();
+ 
     public static async Task<bool> GetValue(string name, bool defaultValue)
     {
         var value = await GetValue(name);

--- a/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor
+++ b/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor
@@ -1,9 +1,9 @@
 ﻿<p>
 	<span style="font-size: 10px" title="@(MoneizAppContext.BuildDate)">Moneiz v@(MoneizAppContext.Version) built on @(BuildDateAttribute.Get()?.ToString("yyyy-MM-dd"))</span>
 
-	@if (!isLastVersion)
+	@if (isUpdateAvailable)
 	{
-		<a href="javascript:MoneizUpdate()" class="new-version-available"><i class="fas fa-sync"></i> Update to the lastest version</a>
+		<a href="javascript:MoneizUpdate()" class="new-version-available"><i class="fas fa-sync"></i> Update to the latest version</a>
 	}
 	else
 	{
@@ -15,39 +15,31 @@
 	<a href="https://github.com/meziantou/meziantou.moneiz/issues" target="_blank"><i class="fas fa-bug"></i> Report issues</a>
 </p>
 
+@implements IDisposable
+
 @code {
-	bool isLastVersion = true;
+	private bool isUpdateAvailable;
+	private System.Threading.Timer? timer;
 
 	protected override async Task OnInitializedAsync()
 	{
-		if (MoneizAppContext.Hash == null)
-			return;
-
-		try
-		{
-			using var client = new HttpClient();
-			var commits = await client.GetFromJsonAsync<Commit[]>("https://api.github.com/repos/meziantou/meziantou.moneiz/commits");
-			if (commits == null)
-				throw new InvalidOperationException("Cannot get commits from GitHub.");
-
-			var lastCommit = commits.FirstOrDefault();
-			if (lastCommit != null)
-			{
-				if (!lastCommit.Sha.EqualsIgnoreCase(MoneizAppContext.Hash))
-				{
-					isLastVersion = false;
-				}
-			}
-		}
-		catch (Exception ex)
-		{
-			Console.WriteLine(ex);
-		}
+		timer = new System.Threading.Timer(CheckForUpdateAvailability, state: null, TimeSpan.FromSeconds(60), TimeSpan.FromMinutes(5));
+		await RefreshUpdateAvailability();
 	}
 
-	private sealed class Commit
+	public void Dispose()
 	{
-		[System.Text.Json.Serialization.JsonPropertyName("sha")]
-		public string? Sha { get; set; }
+		timer?.Dispose();
+	}
+
+	private void CheckForUpdateAvailability(object? state)
+	{
+		InvokeAsync(RefreshUpdateAvailability);
+	}
+
+	private async Task RefreshUpdateAvailability()
+	{
+		isUpdateAvailable = await GlobalInterop.HasUpdateAvailable();
+		StateHasChanged();
 	}
 }

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -31,10 +31,37 @@ function MoneizDownloadFile(name, content) {
 }
 
 async function MoneizUpdate() {
+  if (!("serviceWorker" in navigator)) {
+    location.reload();
+    return;
+  }
+
   const serviceWorker = await navigator.serviceWorker.ready;
   await serviceWorker.update();
-  await serviceWorker.unregister();
-  location.reload(true);
+  if (serviceWorker.waiting) {
+    const controllerChange = new Promise(resolve => {
+      navigator.serviceWorker.addEventListener("controllerchange", resolve, { once: true });
+    });
+
+    serviceWorker.waiting.postMessage({ type: "SKIP_WAITING" });
+    await controllerChange;
+  }
+
+  location.reload();
+}
+
+async function MoneizHasUpdateAvailable() {
+  if (!("serviceWorker" in navigator)) {
+    return false;
+  }
+
+  const registration = await navigator.serviceWorker.getRegistration();
+  if (!registration) {
+    return false;
+  }
+
+  await registration.update();
+  return !!registration.waiting;
 }
 
 function MoneizTrapEnterKey(element) {

--- a/src/Meziantou.Moneiz/wwwroot/service-worker.published.js
+++ b/src/Meziantou.Moneiz/wwwroot/service-worker.published.js
@@ -5,6 +5,7 @@ self.importScripts('./service-worker-assets.js');
 self.addEventListener('install', event => event.waitUntil(onInstall(event)));
 self.addEventListener('activate', event => event.waitUntil(onActivate(event)));
 self.addEventListener('fetch', event => event.respondWith(onFetch(event)));
+self.addEventListener('message', event => onMessage(event));
 
 const cacheNamePrefix = 'offline-cache-';
 const cacheName = `${cacheNamePrefix}${self.assetsManifest.version}`;
@@ -50,4 +51,10 @@ async function onFetch(event) {
   }
 
   return cachedResponse || fetch(event.request);
+}
+
+function onMessage(event) {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    self.skipWaiting();
+  }
 }


### PR DESCRIPTION
The version badge was using GitHub commits to infer whether the running PWA was outdated. For an installed/offline app, the reliable signal is the service worker update lifecycle on the client, so this switches update detection to the browser-native flow.

## What changed
- Replaced `ApplicationVersion` commit polling with a service-worker update check (`MoneizHasUpdateAvailable`) and kept the existing UI behavior: show **Update to the latest version** when an update is pending, otherwise **Force update**.
- Added a new JS interop entry in `GlobalInterop` for update availability.
- Updated `MoneizUpdate()` to apply waiting workers using `SKIP_WAITING` + `controllerchange` and then reload, instead of unregistering the service worker.
- Added service worker message handling in `service-worker.published.js` to process `SKIP_WAITING`.

## Notes for reviewers
This intentionally removes the GitHub API dependency for freshness checks and bases update prompts on same-origin runtime state, which is more accurate for PWA clients.