### PR TITLE
Fix quick amount edit for non-invariant cultures (#181)

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -147,8 +147,8 @@ else
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Amount)
                         {
                             <input type="number" @ref="inlineEditorInput"
-                                   value="@currentEdit.Amount"
-                                   @oninput="e => currentEdit.Amount = Convert.ToDecimal(e.Value)"
+                                   value="@currentEdit.Amount.ToString(CultureInfo.InvariantCulture)"
+                                   @oninput="e => { if (decimal.TryParse((string?)e.Value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedAmount)) currentEdit.Amount = parsedAmount; }"
                                    @onkeydown="e => InlineEditorKeyDown(e)"
                                    @onblur="e => EndInlineEdit()" />
                         }


### PR DESCRIPTION
Fixes #181

## Root cause

The inline amount editor in the transaction list had two culture-related bugs:

### Bug 1 — Blank input field on open (decimal values)

`decimal.ToString()` uses the current thread culture. On machines with a comma decimal separator (French, German, …), `2.5m` renders as `"2,5"`. An `<input type="number">` only accepts invariant-format values, so it shows an empty field.

### Bug 2 — Immediate error while typing

`Convert.ToDecimal(e.Value)` throws on any partial input (`""`, `"-"`, `"1."`, …) that occurs while the user is typing — causing an immediate error message.

## Fix

- Format the input value with `CultureInfo.InvariantCulture` so decimal values display correctly.
- Replace `Convert.ToDecimal` with `decimal.TryParse(..., CultureInfo.InvariantCulture, ...)` so partial input is silently ignored instead of throwing.