### PR TITLE
Add sidebar max-width setting and fix version text overflow

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
+++ b/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
@@ -23,6 +23,13 @@
         </label>
     </div>
 
+    <div class="form-group">
+        <label>
+            Sidebar max width (px, empty for no limit)
+            <InputNumber @bind-Value="displaySettings.SidebarMaxWidth" />
+        </label>
+    </div>
+
     <button type="submit">Save</button>
 </EditForm>
 

--- a/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
+++ b/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
@@ -7,7 +7,7 @@ public class MoneizDisplaySettings
     public int PageSize { get; set; } = 150;
     public string? DateFormat { get; set; }
     public bool FullWidth { get; set; }
-    public int? SidebarMaxWidth { get; set; }
+    public int? SidebarMaxWidth { get; set; } = 400;
 
     public string FormatDate(DateOnly date) => DateFormat is null ? date.ToShortDateString() : date.ToString(DateFormat, CultureInfo.InvariantCulture);
     public string? FormatDate(DateOnly? date) => DateFormat is null ? date?.ToShortDateString() : date?.ToString(DateFormat, CultureInfo.InvariantCulture);

--- a/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
+++ b/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
@@ -7,6 +7,7 @@ public class MoneizDisplaySettings
     public int PageSize { get; set; } = 150;
     public string? DateFormat { get; set; }
     public bool FullWidth { get; set; }
+    public int? SidebarMaxWidth { get; set; }
 
     public string FormatDate(DateOnly date) => DateFormat is null ? date.ToShortDateString() : date.ToString(DateFormat, CultureInfo.InvariantCulture);
     public string? FormatDate(DateOnly? date) => DateFormat is null ? date?.ToShortDateString() : date?.ToString(DateFormat, CultureInfo.InvariantCulture);

--- a/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor
+++ b/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor
@@ -1,5 +1,5 @@
 ﻿<p>
-	<span style="font-size: 10px" title="@(MoneizAppContext.BuildDate)">Moneiz v@(MoneizAppContext.Version) built on @(BuildDateAttribute.Get()?.ToString("yyyy-MM-dd"))</span>
+	<span class="version-text" title="@(MoneizAppContext.BuildDate)">Moneiz v@(MoneizAppContext.Version) built on @(BuildDateAttribute.Get()?.ToString("yyyy-MM-dd"))</span>
 
 	@if (isUpdateAvailable)
 	{

--- a/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor.css
+++ b/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor.css
@@ -1,3 +1,11 @@
 ﻿.new-version-available {
   background-color: yellow;
 }
+
+.version-text {
+  font-size: 10px;
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/src/Meziantou.Moneiz/Shared/MainLayout.razor
+++ b/src/Meziantou.Moneiz/Shared/MainLayout.razor
@@ -31,7 +31,7 @@
 
     <OverdraftWarning />
 
-    <div class="grid-container container">
+    <div class="grid-container container" style="@(sidebarMaxWidth.HasValue ? $"--sidebar-max-width: {sidebarMaxWidth.Value}px" : "")">
         <NavMenu />
 
         <main class="site-main">
@@ -42,11 +42,13 @@
 
 @code {
     bool fullWidth;
+    int? sidebarMaxWidth;
 
     protected override async Task OnInitializedAsync()
     {
         var settings = await SettingsProvider.GetDisplaySettings();
         fullWidth = settings.FullWidth;
+        sidebarMaxWidth = settings.SidebarMaxWidth;
     }
 
     private async Task ToggleFullWidth()

--- a/src/Meziantou.Moneiz/wwwroot/css/_layout.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_layout.css
@@ -13,7 +13,7 @@ body {
 
 .grid-container {
     display: grid;
-    grid-template-columns: minmax(300px, 1fr) 3fr;
+    grid-template-columns: minmax(300px, var(--sidebar-max-width, 1fr)) 3fr;
     grid-gap: 10px;
     justify-items: stretch;
     align-items: stretch;

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -975,7 +975,7 @@ body {
 
 .grid-container {
     display: grid;
-    grid-template-columns: minmax(300px, 1fr) 3fr;
+    grid-template-columns: minmax(300px, var(--sidebar-max-width, 1fr)) 3fr;
     grid-gap: 10px;
     justify-items: stretch;
     align-items: stretch;


### PR DESCRIPTION
Users on wide screens have no way to cap the sidebar width, causing it to grow too large. The version text in the sidebar footer also wraps and can overflow its container.

**Sidebar max-width setting**

A new `SidebarMaxWidth` (`int?`) property is added to `MoneizDisplaySettings`. When set, it is applied as a `--sidebar-max-width` CSS variable on the grid container in `MainLayout`, and the sidebar column uses `minmax(300px, var(--sidebar-max-width, 1fr))` so the sidebar is constrained at wide viewports. Leaving the field empty (null) preserves the current unconstrained `1fr` behavior.

The setting is exposed in the Display Settings page (`/settings`) as a numeric input with a label indicating that leaving it empty means no limit.

**Version text ellipsis**

The version `<span>` in `ApplicationVersion` is now styled with `display: block; white-space: nowrap; overflow: hidden; text-overflow: ellipsis` via a scoped `.version-text` CSS class, replacing the previous inline `style` attribute. The existing `title` attribute already contains the build date, so hovering reveals the full text when it is truncated.