### PR TITLE
Add collapsible category groups in the analytics big table

### DIFF
--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
@@ -10,9 +10,11 @@ public sealed class AnalyticsOptions
 
     public ISet<int> BigTableDisabledCategories { get; } = new HashSet<int>();
     public ISet<string> BigTableDisabledCategoryGroups { get; } = new HashSet<string>(StringComparer.Ordinal);
+    public ISet<string> BigTableCollapsedCategoryGroups { get; } = new HashSet<string>(StringComparer.Ordinal);
 
     public bool IsGroupEnabled(string? name) => !BigTableDisabledCategoryGroups.Contains(name ?? "");
     public bool IsCategoryEnabled(int categoryId) => !BigTableDisabledCategories.Contains(categoryId);
+    public bool IsGroupCollapsed(string? name) => BigTableCollapsedCategoryGroups.Contains(name ?? "");
 
     public void ToggleDisabledCategory(int categoryId)
     {
@@ -30,6 +32,17 @@ public sealed class AnalyticsOptions
         if (!BigTableDisabledCategoryGroups.Remove(name))
         {
             _ = BigTableDisabledCategoryGroups.Add(name);
+        }
+
+        OptionChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void ToggleCollapsedCategoryGroup(string? name)
+    {
+        name ??= "";
+        if (!BigTableCollapsedCategoryGroups.Remove(name))
+        {
+            _ = BigTableCollapsedCategoryGroups.Add(name);
         }
 
         OptionChanged?.Invoke(this, EventArgs.Empty);

--- a/src/Meziantou.Moneiz/Pages/Analytics/BigTable.razor
+++ b/src/Meziantou.Moneiz/Pages/Analytics/BigTable.razor
@@ -15,9 +15,18 @@
 	<tbody>
 		@foreach (var group in Model.CategoryGroups)
 		{
+			var collapsed = Options.IsGroupCollapsed(group.Name);
 			<tr class="bigtable-categorygroup @(!Options.IsGroupEnabled(group.Name) ? "bigtable-disabled" : "")">
 				<td class="bigtable-checkbox"><label><input type="checkbox" @onclick="() => Options.ToggleDisabledCategoryGroup(group.Name)" checked="@Options.IsGroupEnabled(group.Name)" /></label></td>
-				<td class="bigtable-categorygroupname">@group.DisplayName</td>
+				<td class="bigtable-categorygroupname">
+					@if (!group.IsUnclassified)
+					{
+						<button class="bigtable-collapse-btn" title="@(collapsed ? "Expand" : "Collapse")" @onclick="() => Options.ToggleCollapsedCategoryGroup(group.Name)">
+							<span class="bigtable-collapse-icon @(collapsed ? "bigtable-collapse-icon--collapsed" : "")"></span>
+						</button>
+					}
+					@group.DisplayName
+				</td>
 				@foreach (var total in group.Totals)
 				{
 					<td><BigTableCell Cell="total" ShowDetails="ShowDetails" /></td>
@@ -25,7 +34,7 @@
 				<td class="bigtable-totals"><BigTableCell Cell="group.Total" ShowDetails="ShowDetails" /></td>
 			</tr>
 
-			@if (!group.IsUnclassified)
+			@if (!group.IsUnclassified && !collapsed)
 			{
 				@foreach (var category in group.Categories)
 				{

--- a/src/Meziantou.Moneiz/wwwroot/css/_big-table.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_big-table.css
@@ -52,3 +52,28 @@ th.bigtable-totals {
 .bigtable-disabled {
     opacity: 50%;
 }
+
+.bigtable-collapse-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0 4px 0 0;
+    line-height: 1;
+    color: inherit;
+    vertical-align: middle;
+}
+
+.bigtable-collapse-icon {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid currentColor;
+    transition: transform 0.15s ease;
+    vertical-align: middle;
+}
+
+    .bigtable-collapse-icon--collapsed {
+        transform: rotate(-90deg);
+    }

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -130,6 +130,31 @@ th.bigtable-totals {
 .bigtable-disabled {
     opacity: 50%;
 }
+
+.bigtable-collapse-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 0 4px 0 0;
+    line-height: 1;
+    color: inherit;
+    vertical-align: middle;
+}
+
+.bigtable-collapse-icon {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid currentColor;
+    transition: transform 0.15s ease;
+    vertical-align: middle;
+}
+
+    .bigtable-collapse-icon--collapsed {
+        transform: rotate(-90deg);
+    }
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;


### PR DESCRIPTION
The analytics big table shows category groups with all their categories always expanded. For tables with many categories, this makes the view hard to scan. This PR adds the ability to collapse/expand individual category groups.

## What changed

- **`AnalyticsOptions`**: tracks collapsed groups in a new `BigTableCollapsedCategoryGroups` set, with `IsGroupCollapsed()` and `ToggleCollapsedCategoryGroup()` helpers (same pattern as the existing enabled/disabled tracking).
- **`BigTable.razor`**: each non-unclassified group row now renders a small chevron button. Clicking it toggles the group's collapsed state, hiding or showing all category rows beneath it.
- **`_big-table.css`**: styles for the borderless toggle button and an animated CSS triangle that rotates 90 degrees when the group is collapsed.

Collapsing a group only hides the individual category rows from view -- it has no effect on which categories are included in the totals (that is still controlled by the existing checkboxes).