### PR TITLE
Set transaction amount input step to 0.01

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
@@ -76,7 +76,7 @@
 		<div class="form-group">
 			<label>
 				Amount
-				<InputNumber @bind-Value="model.Amount" />
+				<InputNumber @bind-Value="model.Amount" step="0.01" />
 			</label>
 		</div>
 

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -147,6 +147,7 @@ else
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Amount)
                         {
                             <input type="number" @ref="inlineEditorInput"
+                                   step="0.01"
                                    value="@currentEdit.Amount.ToString(CultureInfo.InvariantCulture)"
                                    @oninput="e => { if (decimal.TryParse((string?)e.Value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedAmount)) currentEdit.Amount = parsedAmount; }"
                                    @onkeydown="e => InlineEditorKeyDown(e)"


### PR DESCRIPTION
Amount editors should support cent-level increments so users can adjust values reliably with numeric controls.

## What changed
- Set `step="0.01"` on the inline amount quick-edit input in the transactions list.
- Set `step="0.01"` on the amount input in the transaction edit/create page.

This keeps amount entry behavior consistent between quick edit and full edit.