### PR TITLE
Add collapse and expand all actions to BigTable

### DIFF
--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
@@ -47,4 +47,22 @@ public sealed class AnalyticsOptions
 
         OptionChanged?.Invoke(this, EventArgs.Empty);
     }
+
+    public void CollapseCategoryGroups(IEnumerable<string?> names)
+    {
+        BigTableCollapsedCategoryGroups.Clear();
+
+        foreach (var name in names)
+        {
+            _ = BigTableCollapsedCategoryGroups.Add(name ?? "");
+        }
+
+        OptionChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void ExpandAllCategoryGroups()
+    {
+        BigTableCollapsedCategoryGroups.Clear();
+        OptionChanged?.Invoke(this, EventArgs.Empty);
+    }
 }

--- a/src/Meziantou.Moneiz/Pages/Analytics/BigTable.razor
+++ b/src/Meziantou.Moneiz/Pages/Analytics/BigTable.razor
@@ -1,5 +1,14 @@
 ﻿@using Meziantou.Moneiz.Core.Analytics
 
+@if (HasCollapsibleGroups)
+{
+	<div class="form-group bigtable-actions">
+		<button type="button" @onclick="CollapseAllGroups" disabled="@AreAllGroupsCollapsed">Collapse all</button>
+		<button type="button" @onclick="ExpandAllGroups" disabled="@AreAllGroupsExpanded">Expand all</button>
+	</div>
+}
+
+
 <table class="bigtable">
 	<thead>
 		<tr>
@@ -72,4 +81,19 @@
 
 	[CascadingParameter]
 	public Meziantou.Moneiz.Core.Analytics.AnalyticsOptions Options { get; set; } = null!;
+
+	private IEnumerable<BigTableCategoryGroup> CollapsibleGroups => Model.CategoryGroups.Where(group => !group.IsUnclassified);
+	private bool HasCollapsibleGroups => CollapsibleGroups.Any();
+	private bool AreAllGroupsCollapsed => CollapsibleGroups.All(group => Options.IsGroupCollapsed(group.Name));
+	private bool AreAllGroupsExpanded => CollapsibleGroups.All(group => !Options.IsGroupCollapsed(group.Name));
+
+	private void CollapseAllGroups()
+	{
+		Options.CollapseCategoryGroups(CollapsibleGroups.Select(group => group.Name));
+	}
+
+	private void ExpandAllGroups()
+	{
+		Options.ExpandAllCategoryGroups();
+	}
 }

--- a/src/Meziantou.Moneiz/wwwroot/css/_big-table.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_big-table.css
@@ -2,6 +2,10 @@
     padding-left: 20px;
 }
 
+.bigtable-actions button + button {
+    margin-left: 8px;
+}
+
 .bigtable-categorygroup,
 .balancehistory-currency {
     background-color: var(--border-color);

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -80,6 +80,10 @@ ul.unstyled > li {
     padding-left: 20px;
 }
 
+.bigtable-actions button + button {
+    margin-left: 8px;
+}
+
 .bigtable-categorygroup,
 .balancehistory-currency {
     background-color: var(--border-color);


### PR DESCRIPTION
## Why
The analytics BigTable already supports per-group collapse, but reviewing large tables requires repeating the same action for each group. This adds one-click controls to quickly switch between a fully collapsed and fully expanded view.

## What changed
- Added `CollapseCategoryGroups(IEnumerable<string?> names)` and `ExpandAllCategoryGroups()` to `AnalyticsOptions` so bulk collapse state changes go through the same option-change flow.
- Added `Collapse all` and `Expand all` buttons above the BigTable, shown only when there are collapsible groups.
- Disabled each action button when it is already at the target state to avoid no-op interactions.
- Added a small spacing rule for the new action buttons in `_big-table.css` (and regenerated `site.css` via the existing CSS concatenation step).