### PR TITLE
Add month, quarter, and year grouping for analytics big table

### DIFF
--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsModel.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsModel.cs
@@ -74,19 +74,27 @@ public sealed class AnalyticsModel
     {
         var fromDate = options.FromDate;
         var toDate = options.ToDate;
+        var dateGrouping = options.BigTableDateGrouping;
 
         var transactionGroups = database.Transactions
             .Where(t => t.Account is not null && options.SelectedAccounts.Contains(t.Account) && t.ValueDate >= fromDate && t.ValueDate <= toDate)
             .GroupBy(c => c.Category);
 
+        var firstBucketDate = GetDateBucketStart(fromDate, dateGrouping);
+        var lastBucketDate = GetDateBucketStart(toDate, dateGrouping);
+        var bucketIncrementInMonths = GetBucketIncrementInMonths(dateGrouping);
+        var dates = new List<DateOnly>();
+        for (var date = firstBucketDate; date <= lastBucketDate; date = date.AddMonths(bucketIncrementInMonths))
+        {
+            dates.Add(date);
+        }
+
         var bigTable = new BigTable
         {
-            Dates = new DateOnly[((toDate.Year - fromDate.Year) * 12) + (toDate.Month - fromDate.Month) + 1],
+            DateGrouping = dateGrouping,
+            Dates = [.. dates],
         };
-        for (var i = 0; i < bigTable.Dates.Length; i++)
-        {
-            bigTable.Dates[i] = fromDate.AddMonths(i);
-        }
+        var dateToIndex = bigTable.Dates.Select((date, index) => (date, index)).ToDictionary(value => value.date, value => value.index);
 
         foreach (var group in transactionGroups)
         {
@@ -121,7 +129,8 @@ public sealed class AnalyticsModel
             {
                 if (options.IsCategoryEnabled(transaction.CategoryId ?? -1) && options.IsGroupEnabled(transaction.Category?.GroupName ?? ""))
                 {
-                    var index = ((transaction.ValueDate.Year - fromDate.Year) * 12) + (transaction.ValueDate.Month - fromDate.Month);
+                    var bucketDate = GetDateBucketStart(transaction.ValueDate, dateGrouping);
+                    var index = dateToIndex[bucketDate];
                     bigTableCategory.Totals[index].Add(transaction.Amount);
                 }
             }
@@ -135,6 +144,28 @@ public sealed class AnalyticsModel
         }
 
         return bigTable;
+    }
+
+    private static int GetBucketIncrementInMonths(BigTableDateGrouping bigTableDateGrouping)
+    {
+        return bigTableDateGrouping switch
+        {
+            BigTableDateGrouping.Month => 1,
+            BigTableDateGrouping.Quarter => 3,
+            BigTableDateGrouping.Year => 12,
+            _ => throw new ArgumentOutOfRangeException(nameof(bigTableDateGrouping)),
+        };
+    }
+
+    private static DateOnly GetDateBucketStart(DateOnly value, BigTableDateGrouping bigTableDateGrouping)
+    {
+        return bigTableDateGrouping switch
+        {
+            BigTableDateGrouping.Month => new DateOnly(value.Year, value.Month, 1),
+            BigTableDateGrouping.Quarter => new DateOnly(value.Year, ((value.Month - 1) / 3 * 3) + 1, 1),
+            BigTableDateGrouping.Year => new DateOnly(value.Year, 1, 1),
+            _ => throw new ArgumentOutOfRangeException(nameof(bigTableDateGrouping)),
+        };
     }
 
     private sealed class NameComparer : IComparer<BigTableCategoryGroup>, IComparer<BigTableCategory>, IComparer<string>

--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
@@ -48,8 +48,6 @@ public sealed class AnalyticsOptions
 
         OptionChanged?.Invoke(this, EventArgs.Empty);
     }
-<<<<<<< HEAD
-
     public void CollapseCategoryGroups(IEnumerable<string?> names)
     {
         BigTableCollapsedCategoryGroups.Clear();

--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
@@ -6,6 +6,7 @@ public sealed class AnalyticsOptions
 
     public DateOnly FromDate { get; set; } = Database.GetToday().AddDays(-30);
     public DateOnly ToDate { get; set; } = Database.GetToday();
+    public BigTableDateGrouping BigTableDateGrouping { get; set; } = BigTableDateGrouping.Month;
     public ISet<Account> SelectedAccounts { get; } = new HashSet<Account>();
 
     public ISet<int> BigTableDisabledCategories { get; } = new HashSet<int>();
@@ -47,6 +48,7 @@ public sealed class AnalyticsOptions
 
         OptionChanged?.Invoke(this, EventArgs.Empty);
     }
+<<<<<<< HEAD
 
     public void CollapseCategoryGroups(IEnumerable<string?> names)
     {
@@ -65,4 +67,11 @@ public sealed class AnalyticsOptions
         BigTableCollapsedCategoryGroups.Clear();
         OptionChanged?.Invoke(this, EventArgs.Empty);
     }
+}
+
+public enum BigTableDateGrouping
+{
+    Month,
+    Quarter,
+    Year,
 }

--- a/src/Meziantou.Moneiz.Core/Analytics/BigTable.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/BigTable.cs
@@ -3,6 +3,7 @@
 public sealed class BigTable
 {
     public DateOnly[] Dates { get; set; } = [];
+    public BigTableDateGrouping DateGrouping { get; set; }
     public List<BigTableCategoryGroup> CategoryGroups { get; } = [];
 
     public BigTableValue[] Totals { get; private set; } = [];

--- a/src/Meziantou.Moneiz/Pages/Analytics/BigTable.razor
+++ b/src/Meziantou.Moneiz/Pages/Analytics/BigTable.razor
@@ -16,7 +16,7 @@
 			<th></th>
 			@foreach (var date in Model.Dates)
 			{
-				<th>@date.ToString("MMM yy")</th>
+				<th>@GetDateHeader(date, Model.DateGrouping)</th>
 			}
 			<th class="bigtable-totals">Total</th>
 		</tr>
@@ -95,5 +95,16 @@
 	private void ExpandAllGroups()
 	{
 		Options.ExpandAllCategoryGroups();
+	}
+
+	private static string GetDateHeader(DateOnly date, BigTableDateGrouping dateGrouping)
+	{
+		return dateGrouping switch
+		{
+			BigTableDateGrouping.Month => date.ToString("MMM yy"),
+			BigTableDateGrouping.Quarter => $"Q{((date.Month - 1) / 3) + 1} {date.Year}",
+			BigTableDateGrouping.Year => date.ToString("yyyy"),
+			_ => throw new ArgumentOutOfRangeException(nameof(dateGrouping)),
+		};
 	}
 }

--- a/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
@@ -71,6 +71,15 @@
 			<input type="date" id="PeriodTo" @bind-value="@options.ToDate" />
 		</div>
 
+		<div class="form-group">
+			<label for="BigTableDateGrouping">Big table grouping</label>
+			<select id="BigTableDateGrouping" @bind="@options.BigTableDateGrouping">
+				<option value="@BigTableDateGrouping.Month">Month</option>
+				<option value="@BigTableDateGrouping.Quarter">Quarter</option>
+				<option value="@BigTableDateGrouping.Year">Year</option>
+			</select>
+		</div>
+
 		<button type="button" @onclick="() => Generate()">Generate</button>
 
 		@if (model != null)

--- a/tests/Meziantou.Moneiz.CoreTests/AnalyticsModelTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/AnalyticsModelTests.cs
@@ -51,4 +51,47 @@ public sealed class AnalyticsModelTests
 
         Assert.Equal(result.BigTable!.Totals[^1].Total, result.BalanceHistory.BalancesByAccount[0].Difference);
     }
+
+    [Theory]
+    [InlineData(BigTableDateGrouping.Month, "2023-01-01,2023-02-01,2023-03-01,2023-04-01,2023-05-01,2023-06-01,2023-07-01,2023-08-01,2023-09-01,2023-10-01,2023-11-01,2023-12-01", "10,0,-2,0,0,0,0,0,0,0,5,0")]
+    [InlineData(BigTableDateGrouping.Quarter, "2023-01-01,2023-04-01,2023-07-01,2023-10-01", "8,0,0,5")]
+    [InlineData(BigTableDateGrouping.Year, "2023-01-01", "13")]
+    public void ComputeModel_BigTableGrouping(BigTableDateGrouping bigTableDateGrouping, string expectedDates, string expectedTotals)
+    {
+        var database = new Database();
+        var account = new Account();
+        database.Accounts.Add(account);
+
+        database.Transactions.Add(new Transaction
+        {
+            Account = account,
+            ValueDate = new DateOnly(2023, 1, 20),
+            Amount = 10m,
+        });
+
+        database.Transactions.Add(new Transaction
+        {
+            Account = account,
+            ValueDate = new DateOnly(2023, 3, 10),
+            Amount = -2m,
+        });
+
+        database.Transactions.Add(new Transaction
+        {
+            Account = account,
+            ValueDate = new DateOnly(2023, 11, 5),
+            Amount = 5m,
+        });
+
+        var result = AnalyticsModel.Build(database, new AnalyticsOptions
+        {
+            FromDate = new DateOnly(2023, 1, 15),
+            ToDate = new DateOnly(2023, 12, 20),
+            BigTableDateGrouping = bigTableDateGrouping,
+            SelectedAccounts = { account },
+        });
+
+        Assert.Equal(expectedDates, string.Join(",", result.BigTable!.Dates.Select(date => date.ToString("yyyy-MM-dd"))));
+        Assert.Equal(expectedTotals, string.Join(",", result.BigTable.Totals.Select(total => total.Total)));
+    }
 }


### PR DESCRIPTION
## Summary
The analytics big table was always grouped by month, which made long-period analysis harder to scan. This change adds an explicit grouping option so users can switch between month, quarter, and year buckets.

## What changed
- Added `BigTableDateGrouping` to analytics options with `Month` as the default.
- Updated big table aggregation to bucket transactions by the selected grouping and generate matching date columns.
- Stored the selected grouping on the big table model so rendering can format headers correctly.
- Added a new Analytics page selector (`Month`, `Quarter`, `Year`) for big table grouping.
- Updated big table headers to render by grouping (`MMM yy`, `Qn yyyy`, `yyyy`).
- Added/updated analytics model tests to verify month, quarter, and year bucket generation and totals.

## Notes
- The default behavior remains monthly grouping, so existing usage is preserved unless the new option is changed by the user.