### PR TITLE
Fix zero-amount false matches in transaction search

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/TransactionQuery.cs
+++ b/src/Meziantou.Moneiz/Pages/Transactions/TransactionQuery.cs
@@ -36,7 +36,7 @@ internal static class TransactionQueries
 
         builder.SetTextFilterHandler((transaction, text) =>
         {
-            var amount = ExtractDecimalValues(text)?.LastOrDefault();
+            var amount = ExtractDecimalValues(text).Select(static value => (decimal?)value).LastOrDefault();
             if (MatchStringValue(transaction.FinalTitle, text))
                 return true;
 


### PR DESCRIPTION
Free-text transaction search could incorrectly match transactions with amount `0` when the query contained no valid numeric token.

This change keeps the parsed amount as nullable in the text filter path, so amount comparison only happens when an amount was actually parsed from the search text. This prevents unrelated text queries from returning zero-amount transactions.