### PR TITLE
Add inline category quick-edit to transaction list

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -141,7 +141,18 @@ else
                     {
                         <td title="@transaction.Account!.Name">@transaction.Account.Name</td>
                     }
-                    <td title="@transaction.Category">@transaction.Category?.Name</td>
+                    <td title="@transaction.Category?.Name" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Category)">
+                        @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Category)
+                        {
+                            <EditForm Model="currentEdit" Context="editContext">
+                                <InputSelectCategory @bind-Value="currentEdit.Category" @bind-Value:after="EndInlineEdit" IsOptional="true" />
+                            </EditForm>
+                        }
+                        else
+                        {
+                            @transaction.Category?.Name
+                        }
+                    </td>
                     <td title="@transaction.FinalTitle">@transaction.FinalTitle</td>
                     <td @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Amount)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Amount)
@@ -268,7 +279,7 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (currentEdit is not null && inlineEditorInput.Id is not null)
+        if (currentEdit is not null && editColumn != EditColumn.Category && inlineEditorInput.Id is not null)
         {
             await inlineEditorInput.FocusAsync();
         }
@@ -462,6 +473,7 @@ else
         Amount,
         Comment,
         Date,
+        Category,
     }
 
     private record struct TransactionWithAccountBalance(Transaction Transaction, decimal AccountBalanceAfterTransaction);


### PR DESCRIPTION
Double-clicking the category cell in the transaction list now opens the filterable category dropdown inline, consistent with the existing quick-edit support for amount, comment, and date.

**How it works:**
- Double-clicking the category cell enters inline edit mode, rendering `InputSelectCategory` inside a minimal `EditForm` (needed for the component's `EditContext`).
- Selecting a category saves immediately via `@bind-Value:after="EndInlineEdit"` and exits edit mode.
- `Category` is added to the `EditColumn` enum, and `OnAfterRenderAsync` skips auto-focus for the category column since `InputSelectFilterable` manages its own focus internally.