### PR TITLE
Add quick duplicate action in transaction list

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -189,7 +189,8 @@ else
                     </td>
                     <td class="commands">
                         <Dropdown>
-                            <li><a href="@UrlService.DuplicateTransaction(transaction)" class="duplicate"><i class="fas fa-copy"></i> Duplicate</a></li>
+                            <li><button type="button" class="btn-link duplicate" @onclick="() => QuickDuplicate(transaction)"><i class="fas fa-copy"></i> Quick duplicate</button></li>
+                            <li><a href="@UrlService.DuplicateTransaction(transaction)" class="duplicate"><i class="fas fa-copy"></i> Duplicate and Edit</a></li>
                             <li><a href="@UrlService.EditTransaction(transaction)" class="view-transactions"><i class="fas fa-pencil-alt"></i> Edit</a></li>
                             <li><button type="button" class="btn-link" @onclick="() => Delete(transaction)"><i class="fas fa-trash" style="color: red"></i> Delete</button></li>
 
@@ -325,6 +326,16 @@ else
             await DatabaseProvider.Save();
             LoadTransactions();
         }
+    }
+
+    private async Task QuickDuplicate(Transaction transaction)
+    {
+		Debug.Assert(database != null);
+        var duplicatedTransaction = TransactionEdit.FromTransaction(transaction, createNewTransaction: true);
+        duplicatedTransaction.ValueDate = Database.GetToday();
+        duplicatedTransaction.Save(database);
+        await DatabaseProvider.Save();
+        LoadTransactions();
     }
 
     private async Task Reconcile()


### PR DESCRIPTION
Duplicating transactions is a common flow, and opening the edit form every time adds extra clicks when the copy should be immediate.

This change adds a direct "Quick duplicate" action in the transaction list menu that creates the duplicated transaction immediately and sets its operation date to today. The existing menu action is renamed to "Duplicate and Edit" to make its behavior explicit.

## Changes
1. Added a new `Quick duplicate` dropdown action in the transactions list.
2. Implemented `QuickDuplicate(Transaction transaction)` to:
   - duplicate the selected transaction as a new one,
   - set `ValueDate` to `Database.GetToday()`,
   - save and reload the list.
3. Renamed the existing `Duplicate` menu item to `Duplicate and Edit`.