### PR TITLE
Fix clipped inline editors in transactions table

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -123,7 +123,7 @@ else
                             <div class="btn-transaction-status far fa-square" title="@transaction.State" @onclick="() => Check(transaction)"></div>
                         }
                     </td>
-                    <td @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Date)">
+                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Date)" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Date)">
                         @if (currentEdit?.Id == transaction.Id && editColumn is EditColumn.Date)
                         {
                             <input type="date" @ref="inlineEditorInput"
@@ -141,7 +141,7 @@ else
                     {
                         <td title="@transaction.Account!.Name">@transaction.Account.Name</td>
                     }
-                    <td class="@(currentEdit?.Id == transaction.Id && editColumn == EditColumn.Category ? "inline-editing-category" : null)"
+                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Category)"
                         title="@transaction.Category?.Name"
                         @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Category)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Category)
@@ -156,7 +156,7 @@ else
                         }
                     </td>
                     <td title="@transaction.FinalTitle">@transaction.FinalTitle</td>
-                    <td @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Amount)">
+                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Amount)" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Amount)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Amount)
                         {
                             <input type="number" @ref="inlineEditorInput"
@@ -175,7 +175,7 @@ else
                     {
                         <td><Amount Value="@accountBalance" Currency="@transaction.Account!.CurrencyIsoCode" /></td>
                     }
-                    <td @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Comment)">
+                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Comment)" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Comment)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Comment)
                         {
                             <input type="text" @ref="inlineEditorInput"
@@ -437,6 +437,9 @@ else
         currentEdit = TransactionEdit.FromTransaction(transaction, editCurrentTransaction: true);
         editColumn = column;
     }
+
+    private string? GetInlineEditCellClass(Transaction transaction, EditColumn column)
+        => currentEdit?.Id == transaction.Id && editColumn == column ? "inline-editing" : null;
 
     private async Task InlineEditorKeyDown(KeyboardEventArgs e)
     {

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -141,7 +141,9 @@ else
                     {
                         <td title="@transaction.Account!.Name">@transaction.Account.Name</td>
                     }
-                    <td title="@transaction.Category?.Name" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Category)">
+                    <td class="@(currentEdit?.Id == transaction.Id && editColumn == EditColumn.Category ? "inline-editing-category" : null)"
+                        title="@transaction.Category?.Name"
+                        @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Category)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Category)
                         {
                             <EditForm Model="currentEdit" Context="editContext">

--- a/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
@@ -67,7 +67,7 @@
     overflow: hidden;
   }
 
-  .transaction-list td.inline-editing-category {
+  .transaction-list td.inline-editing {
     overflow: visible;
     position: relative;
     z-index: 1;

--- a/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
@@ -66,3 +66,9 @@
     text-overflow: ellipsis;
     overflow: hidden;
   }
+
+  .transaction-list td.inline-editing-category {
+    overflow: visible;
+    position: relative;
+    z-index: 1;
+  }

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -1206,7 +1206,7 @@ body {
     overflow: hidden;
   }
 
-  .transaction-list td.inline-editing-category {
+  .transaction-list td.inline-editing {
     overflow: visible;
     position: relative;
     z-index: 1;

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -1205,6 +1205,12 @@ body {
     text-overflow: ellipsis;
     overflow: hidden;
   }
+
+  .transaction-list td.inline-editing-category {
+    overflow: visible;
+    position: relative;
+    z-index: 1;
+  }
 .site-sidebar {
     background: var(--hover-bg);
     border-radius: 8px;


### PR DESCRIPTION
Inline editing in the transactions table could clip controls inside cells because table cells use `overflow: hidden` for truncation. This was most visible on category editing where the dropdown could be cut off.

## What changed
- Added a conditional CSS class on editable transaction cells (date, category, amount, comment) only while that specific cell is being inline edited.
- Applied a focused CSS override for inline-edit mode to allow overflow (`overflow: visible`) and proper stacking (`position: relative; z-index: 1`).
- Kept the default truncation behavior for non-editing cells unchanged.

## Notes
- The behavior is now consistent across all inline editors, not just category selection.
- `site.css` was regenerated from the source CSS partials as part of the normal build pipeline.