### PR TITLE
Show full account name (bank + name) in All Transactions page

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -139,7 +139,7 @@ else
                     </td>
                     @if (AccountId is null)
                     {
-                        <td title="@transaction.Account!.Name">@transaction.Account.Name</td>
+                        <td title="@transaction.Account!.ToString()">@transaction.Account.ToString()</td>
                     }
                     <td title="@transaction.Category?.Name" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Category)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Category)


### PR DESCRIPTION
The account column in the All Transactions page was displaying only the account `Name`, omitting the bank name even when one was set.

The `Account.ToString()` method already returns `"Bank - Name"` when a bank is configured, and just `Name` otherwise. The fix replaces `transaction.Account.Name` with `transaction.Account.ToString()` in the account column cell and its tooltip.