### PR TITLE
Add drag-and-drop sorting on the Accounts page

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.Account.cs
+++ b/src/Meziantou.Moneiz.Core/Database.Account.cs
@@ -35,6 +35,33 @@ public partial class Database
 
     public void MoveDownAccount(Account account) => MoveAccount(account, 1);
 
+    public bool MoveAccountBefore(Account account, Account targetAccount)
+    {
+        if (account == targetAccount || account.Closed != targetAccount.Closed)
+            return false;
+
+        var accounts = Accounts
+            .Where(a => a.Closed == account.Closed)
+            .OrderBy(a => a.SortOrder)
+            .ThenBy(a => a.Name, StringComparer.Ordinal)
+            .ToList();
+
+        if (!accounts.Contains(account) || !accounts.Contains(targetAccount))
+            return false;
+
+        _ = accounts.Remove(account);
+        var targetIndex = accounts.IndexOf(targetAccount);
+        accounts.Insert(targetIndex, account);
+
+        for (var i = 0; i < accounts.Count; i++)
+        {
+            accounts[i].SortOrder = i;
+        }
+
+        RaiseDatabaseChanged();
+        return true;
+    }
+
     private void MoveAccount(Account account, int direction)
     {
         var accounts = Accounts.Sort().ToList();

--- a/src/Meziantou.Moneiz/Pages/Accounts/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Accounts/Index.razor
@@ -12,6 +12,7 @@
         <table>
             <thead>
                 <tr>
+                    <th></th>
                     <th>Name</th>
                     <th>Currency</th>
                     <th>Overdraft Warning</th>
@@ -23,7 +24,17 @@
     </RepeaterContainerTemplate>
 
     <ItemTemplate Context="account">
-        <tr>
+        <tr @key="account.Id"
+            class="account-row @(draggedAccount == account ? "dragging" : "")"
+            draggable="true"
+            @ondragstart="() => OnDragStart(account)"
+            @ondragend="OnDragEnd"
+            @ondragover:preventDefault
+            @ondrop:preventDefault
+            @ondrop="() => OnDrop(account)">
+            <td class="drag-handle" title="Drag and drop to reorder">
+                <i class="fas fa-grip-vertical"></i>
+            </td>
             @if (account.Closed)
             {
                 <td>@account (<i class="fas fa-times"></i> closed)</td>
@@ -56,6 +67,7 @@
 
 @code {
     Database? database;
+    Account? draggedAccount;
 
     protected override async Task OnInitializedAsync()
     {
@@ -124,12 +136,35 @@
     }
 
     public async Task Delete(Account account)
-	{
-		Debug.Assert(database != null);
+    {
+        Debug.Assert(database != null);
         if (GlobalInterop.Confirm($"Do you really want to delete '{account}'?"))
         {
             database.RemoveAccount(account);
             await DatabaseProvider.Save();
         }
+    }
+
+    private void OnDragStart(Account account)
+    {
+        draggedAccount = account;
+    }
+
+    private void OnDragEnd()
+    {
+        draggedAccount = null;
+    }
+
+    private async Task OnDrop(Account targetAccount)
+    {
+        if (database is null || draggedAccount is null)
+            return;
+
+        if (database.MoveAccountBefore(draggedAccount, targetAccount))
+        {
+            await DatabaseProvider.Save();
+        }
+
+        draggedAccount = null;
     }
 }

--- a/src/Meziantou.Moneiz/Pages/Accounts/Index.razor.css
+++ b/src/Meziantou.Moneiz/Pages/Accounts/Index.razor.css
@@ -1,0 +1,14 @@
+.account-row {
+  cursor: grab;
+}
+
+.account-row.dragging {
+  opacity: 0.5;
+}
+
+.drag-handle {
+  width: 1%;
+  text-align: center;
+  white-space: nowrap;
+  color: var(--text-color-muted, #888);
+}

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -130,6 +130,38 @@ public class DatabaseTests
     }
 
     [Fact]
+    public void MoveAccountBeforeReordersAccounts()
+    {
+        var database = new Database();
+        var account1 = new Account { Name = "Account 1" };
+        var account2 = new Account { Name = "Account 2" };
+        var account3 = new Account { Name = "Account 3" };
+        database.SaveAccount(account1);
+        database.SaveAccount(account2);
+        database.SaveAccount(account3);
+
+        var updated = database.MoveAccountBefore(account3, account1);
+
+        Assert.True(updated);
+        Assert.Equal([account3, account1, account2], database.VisibleAccounts);
+    }
+
+    [Fact]
+    public void MoveAccountBeforeDoesNotMoveAcrossOpenAndClosedAccounts()
+    {
+        var database = new Database();
+        var openedAccount = new Account { Name = "Opened account" };
+        var closedAccount = new Account { Name = "Closed account", Closed = true };
+        database.SaveAccount(openedAccount);
+        database.SaveAccount(closedAccount);
+
+        var updated = database.MoveAccountBefore(closedAccount, openedAccount);
+
+        Assert.False(updated);
+        Assert.Equal([openedAccount, closedAccount], database.Accounts.Sort());
+    }
+
+    [Fact]
     [SuppressMessage("Performance", "CA1869:Cache and reuse 'JsonSerializerOptions' instances")]
     public void DateOnlyJsonConverter()
     {


### PR DESCRIPTION
## Why
Reordering accounts currently requires using move up/down actions repeatedly, which is slow for larger lists. Drag-and-drop provides a faster and more direct way to organize accounts.

## What changed
- Added row drag-and-drop behavior to `Pages/Accounts/Index.razor` with a visual drag handle and dragging state.
- Added page-scoped styles in `Pages/Accounts/Index.razor.css` for handle visibility and dragged-row feedback.
- Added `Database.MoveAccountBefore(Account account, Account targetAccount)` to persist arbitrary reorder operations by updating `SortOrder`.
- Kept ordering safety constraints by preventing reordering across open and closed account groups.
- Added core tests covering successful reorder and rejected cross-group reorder scenarios.

## Notes for reviewers
The existing Move up/Move down actions remain in place. Drag-and-drop uses the same persisted sort mechanism (`SortOrder`) and triggers the usual database changed/save flow.