### PR TITLE
Fix Payees table headers rendering literal @ symbols

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Payees/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Payees/Index.razor
@@ -14,17 +14,17 @@
 				<tr>
 					<th>
 						<button type="button" style="background: none; border: 0; padding: 0; color: inherit; font: inherit; cursor: pointer;" @onclick="() => SetSort(SortColumn.Name)">
-							Name@SortDirectionIcon(SortColumn.Name)
+							Name @SortDirectionIcon(SortColumn.Name)
 						</button>
 					</th>
 					<th>
 						<button type="button" style="background: none; border: 0; padding: 0; color: inherit; font: inherit; cursor: pointer;" @onclick="() => SetSort(SortColumn.DefaultCategory)">
-							Default category@SortDirectionIcon(SortColumn.DefaultCategory)
+							Default category @SortDirectionIcon(SortColumn.DefaultCategory)
 						</button>
 					</th>
 					<th style="text-align: right">
 						<button type="button" style="background: none; border: 0; padding: 0; color: inherit; font: inherit; cursor: pointer;" @onclick="() => SetSort(SortColumn.Transactions)">
-							# Transactions@SortDirectionIcon(SortColumn.Transactions)
+							# Transactions @SortDirectionIcon(SortColumn.Transactions)
 						</button>
 					</th>
 					<th></th>


### PR DESCRIPTION
Razor's parser treats `text@identifier(...)` as a literal `@` character (the email-address heuristic), so the sort-direction icon calls written as `Name@SortDirectionIcon(...)` were rendered verbatim in the browser instead of being evaluated as C# expressions.

The fix adds a space before each `@SortDirectionIcon(...)` call in the three header buttons, which is how the Categories table already handles the same pattern (`Name @GetSortIndicator(...)`).