### PR TITLE
Fix dropdown clipping in inline category editor

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -9,6 +9,7 @@
 @inject DatabaseProvider DatabaseProvider
 @inject UrlService UrlService
 @inject NavigationManager NavigationManager
+@inject IJSRuntime JSRuntime
 
 @if (account is not null)
 {
@@ -141,14 +142,13 @@ else
                     {
                         <td title="@transaction.Account!.ToString()">@transaction.Account.ToString()</td>
                     }
-                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Category)"
+                    <td id="@GetCategoryEditorCellId(transaction)"
+                        class="@GetInlineEditCellClass(transaction, EditColumn.Category)"
                         title="@transaction.Category?.Name"
                         @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Category)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Category)
                         {
-                            <EditForm Model="currentEdit" Context="editContext">
-                                <InputSelectCategory @bind-Value="currentEdit.Category" @bind-Value:after="EndInlineEdit" IsOptional="true" />
-                            </EditForm>
+                            @currentEdit.Category?.Name
                         }
                         else
                         {
@@ -227,6 +227,15 @@ else
             </tr>
         }
     </table>
+
+    @if (currentEdit is not null && editColumn == EditColumn.Category && inlineCategoryEditorStyle is not null)
+    {
+        <div class="inline-category-editor-overlay" style="@inlineCategoryEditorStyle">
+            <EditForm Model="currentEdit" Context="editContext">
+                <InputSelectCategory @bind-Value="currentEdit.Category" @bind-Value:after="EndInlineEdit" IsOptional="true" />
+            </EditForm>
+        </div>
+    }
 }
 
 
@@ -240,6 +249,7 @@ else
     TransactionEdit? currentEdit = null;
     EditColumn editColumn;
     ElementReference inlineEditorInput;
+    string? inlineCategoryEditorStyle;
 
     [Parameter]
     public int? AccountId { get; set; }
@@ -443,11 +453,21 @@ else
         Console.WriteLine($"LoadTransactions: {sw.ElapsedMilliseconds}ms");
     }
 
-    private void BeginInlineEdit(Transaction transaction, EditColumn column)
+    private async Task BeginInlineEdit(Transaction transaction, EditColumn column)
     {
         currentEdit = TransactionEdit.FromTransaction(transaction, editCurrentTransaction: true);
         editColumn = column;
+        inlineCategoryEditorStyle = null;
+
+        if (column == EditColumn.Category)
+        {
+            var rect = await JSRuntime.InvokeAsync<BoundingClientRect>("MoneizGetBoundingClientRectById", GetCategoryEditorCellId(transaction));
+            inlineCategoryEditorStyle = FormattableString.Invariant($"top: {rect.Bottom}px; left: {rect.Left}px; width: {rect.Width}px;");
+        }
     }
+
+    private static string GetCategoryEditorCellId(Transaction transaction)
+        => FormattableString.Invariant($"transaction-category-cell-{transaction.Id}");
 
     private string? GetInlineEditCellClass(Transaction transaction, EditColumn column)
         => currentEdit?.Id == transaction.Id && editColumn == column ? "inline-editing" : null;
@@ -461,6 +481,7 @@ else
         else if (e.Key == "Escape")
         {
             currentEdit = null;
+            inlineCategoryEditorStyle = null;
         }
     }
 
@@ -472,6 +493,7 @@ else
             currentEdit.Save(database);
             await DatabaseProvider.Save();
             currentEdit = null;
+            inlineCategoryEditorStyle = null;
             LoadTransactions();
         }
     }
@@ -493,4 +515,5 @@ else
     }
 
     private record struct TransactionWithAccountBalance(Transaction Transaction, decimal AccountBalanceAfterTransaction);
+    private record struct BoundingClientRect(double Bottom, double Left, double Width);
 }

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -124,14 +124,12 @@ else
                             <div class="btn-transaction-status far fa-square" title="@transaction.State" @onclick="() => Check(transaction)"></div>
                         }
                     </td>
-                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Date)" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Date)">
+                    <td id="@GetInlineEditorCellId(transaction, EditColumn.Date)"
+                        class="@GetInlineEditCellClass(transaction, EditColumn.Date)"
+                        @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Date)">
                         @if (currentEdit?.Id == transaction.Id && editColumn is EditColumn.Date)
                         {
-                            <input type="date" @ref="inlineEditorInput"
-                                   value="@BindConverter.FormatValue(currentEdit.ValueDate, "yyyy-MM-dd", CultureInfo.InvariantCulture)"
-                                   @oninput="e => currentEdit.ValueDate = ParseDate((string?)e.Value, currentEdit.ValueDate)"
-                                   @onkeydown="e => InlineEditorKeyDown(e)"
-                                   @onblur="e => EndInlineEdit()" />
+                            <UserDate Date="@transaction.ValueDate" />
                         }
                         else
                         {
@@ -142,7 +140,7 @@ else
                     {
                         <td title="@transaction.Account!.ToString()">@transaction.Account.ToString()</td>
                     }
-                    <td id="@GetCategoryEditorCellId(transaction)"
+                    <td id="@GetInlineEditorCellId(transaction, EditColumn.Category)"
                         class="@GetInlineEditCellClass(transaction, EditColumn.Category)"
                         title="@transaction.Category?.Name"
                         @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Category)">
@@ -156,15 +154,12 @@ else
                         }
                     </td>
                     <td title="@transaction.FinalTitle">@transaction.FinalTitle</td>
-                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Amount)" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Amount)">
+                    <td id="@GetInlineEditorCellId(transaction, EditColumn.Amount)"
+                        class="@GetInlineEditCellClass(transaction, EditColumn.Amount)"
+                        @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Amount)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Amount)
                         {
-                            <input type="number" @ref="inlineEditorInput"
-                                   step="0.01"
-                                   value="@currentEdit.Amount.ToString(CultureInfo.InvariantCulture)"
-                                   @oninput="e => { if (decimal.TryParse((string?)e.Value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedAmount)) currentEdit.Amount = parsedAmount; }"
-                                   @onkeydown="e => InlineEditorKeyDown(e)"
-                                   @onblur="e => EndInlineEdit()" />
+                            <Amount Value="@transaction.Amount" Currency="@transaction.Account!.CurrencyIsoCode" />
                         }
                         else
                         {
@@ -175,14 +170,12 @@ else
                     {
                         <td><Amount Value="@accountBalance" Currency="@transaction.Account!.CurrencyIsoCode" /></td>
                     }
-                    <td class="@GetInlineEditCellClass(transaction, EditColumn.Comment)" @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Comment)">
+                    <td id="@GetInlineEditorCellId(transaction, EditColumn.Comment)"
+                        class="@GetInlineEditCellClass(transaction, EditColumn.Comment)"
+                        @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Comment)">
                         @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Comment)
                         {
-                            <input type="text" @ref="inlineEditorInput"
-                                   value="@currentEdit.Comment"
-                                   @oninput="e => currentEdit.Comment = (string?)e.Value"
-                                   @onkeydown="e => InlineEditorKeyDown(e)"
-                                   @onblur="e => EndInlineEdit()" />
+                            @transaction.Comment
                         }
                         else
                         {
@@ -228,12 +221,40 @@ else
         }
     </table>
 
-    @if (currentEdit is not null && editColumn == EditColumn.Category && inlineCategoryEditorStyle is not null)
+    @if (currentEdit is not null && inlineEditorStyle is not null)
     {
-        <div class="inline-category-editor-overlay" style="@inlineCategoryEditorStyle">
-            <EditForm Model="currentEdit" Context="editContext">
-                <InputSelectCategory @bind-Value="currentEdit.Category" @bind-Value:after="EndInlineEdit" IsOptional="true" />
-            </EditForm>
+        <div class="inline-editor-overlay" style="@inlineEditorStyle">
+            @if (editColumn == EditColumn.Date)
+            {
+                <input type="date" @ref="inlineEditorInput"
+                       value="@BindConverter.FormatValue(currentEdit.ValueDate, "yyyy-MM-dd", CultureInfo.InvariantCulture)"
+                       @oninput="e => currentEdit.ValueDate = ParseDate((string?)e.Value, currentEdit.ValueDate)"
+                       @onkeydown="e => InlineEditorKeyDown(e)"
+                       @onblur="e => EndInlineEdit()" />
+            }
+            else if (editColumn == EditColumn.Category)
+            {
+                <EditForm Model="currentEdit" Context="editContext">
+                    <InputSelectCategory @bind-Value="currentEdit.Category" @bind-Value:after="EndInlineEdit" IsOptional="true" />
+                </EditForm>
+            }
+            else if (editColumn == EditColumn.Amount)
+            {
+                <input type="number" @ref="inlineEditorInput"
+                       step="0.01"
+                       value="@currentEdit.Amount.ToString(CultureInfo.InvariantCulture)"
+                       @oninput="e => { if (decimal.TryParse((string?)e.Value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedAmount)) currentEdit.Amount = parsedAmount; }"
+                       @onkeydown="e => InlineEditorKeyDown(e)"
+                       @onblur="e => EndInlineEdit()" />
+            }
+            else if (editColumn == EditColumn.Comment)
+            {
+                <input type="text" @ref="inlineEditorInput"
+                       value="@currentEdit.Comment"
+                       @oninput="e => currentEdit.Comment = (string?)e.Value"
+                       @onkeydown="e => InlineEditorKeyDown(e)"
+                       @onblur="e => EndInlineEdit()" />
+            }
         </div>
     }
 }
@@ -249,7 +270,7 @@ else
     TransactionEdit? currentEdit = null;
     EditColumn editColumn;
     ElementReference inlineEditorInput;
-    string? inlineCategoryEditorStyle;
+    string? inlineEditorStyle;
 
     [Parameter]
     public int? AccountId { get; set; }
@@ -457,17 +478,14 @@ else
     {
         currentEdit = TransactionEdit.FromTransaction(transaction, editCurrentTransaction: true);
         editColumn = column;
-        inlineCategoryEditorStyle = null;
+        inlineEditorStyle = null;
 
-        if (column == EditColumn.Category)
-        {
-            var rect = await JSRuntime.InvokeAsync<BoundingClientRect>("MoneizGetBoundingClientRectById", GetCategoryEditorCellId(transaction));
-            inlineCategoryEditorStyle = FormattableString.Invariant($"top: {rect.Bottom}px; left: {rect.Left}px; width: {rect.Width}px;");
-        }
+        var rect = await JSRuntime.InvokeAsync<BoundingClientRect>("MoneizGetElementDocumentRectById", GetInlineEditorCellId(transaction, column));
+        inlineEditorStyle = FormattableString.Invariant($"top: {rect.Top}px; left: {rect.Left}px; min-width: {rect.Width}px;");
     }
 
-    private static string GetCategoryEditorCellId(Transaction transaction)
-        => FormattableString.Invariant($"transaction-category-cell-{transaction.Id}");
+    private static string GetInlineEditorCellId(Transaction transaction, EditColumn column)
+        => FormattableString.Invariant($"transaction-inline-editor-{transaction.Id}-{column}");
 
     private string? GetInlineEditCellClass(Transaction transaction, EditColumn column)
         => currentEdit?.Id == transaction.Id && editColumn == column ? "inline-editing" : null;
@@ -481,7 +499,7 @@ else
         else if (e.Key == "Escape")
         {
             currentEdit = null;
-            inlineCategoryEditorStyle = null;
+            inlineEditorStyle = null;
         }
     }
 
@@ -493,7 +511,7 @@ else
             currentEdit.Save(database);
             await DatabaseProvider.Save();
             currentEdit = null;
-            inlineCategoryEditorStyle = null;
+            inlineEditorStyle = null;
             LoadTransactions();
         }
     }
@@ -515,5 +533,5 @@ else
     }
 
     private record struct TransactionWithAccountBalance(Transaction Transaction, decimal AccountBalanceAfterTransaction);
-    private record struct BoundingClientRect(double Bottom, double Left, double Width);
+    private record struct BoundingClientRect(double Top, double Left, double Width);
 }

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -223,7 +223,7 @@ else
 
     @if (currentEdit is not null && inlineEditorStyle is not null)
     {
-        <div class="inline-editor-overlay" style="@inlineEditorStyle">
+        <div class="inline-editor-overlay" style="@inlineEditorStyle" @onkeydown="InlineEditorKeyDown">
             @if (editColumn == EditColumn.Date)
             {
                 <input type="date" @ref="inlineEditorInput"
@@ -492,14 +492,14 @@ else
 
     private async Task InlineEditorKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key == "Enter")
-        {
-            await EndInlineEdit();
-        }
-        else if (e.Key == "Escape")
+        if (e.Key == "Escape")
         {
             currentEdit = null;
             inlineEditorStyle = null;
+        }
+        else if (e.Key == "Enter" && editColumn != EditColumn.Category)
+        {
+            await EndInlineEdit();
         }
     }
 

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -271,6 +271,7 @@ else
     EditColumn editColumn;
     ElementReference inlineEditorInput;
     string? inlineEditorStyle;
+    bool focusInlineEditorRequested;
 
     [Parameter]
     public int? AccountId { get; set; }
@@ -313,9 +314,10 @@ else
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        if (currentEdit is not null && editColumn != EditColumn.Category && inlineEditorInput.Id is not null)
+        if (focusInlineEditorRequested && currentEdit is not null && editColumn != EditColumn.Category)
         {
-            await inlineEditorInput.FocusAsync();
+            await JSRuntime.InvokeVoidAsync("MoneizFocusIfConnected", inlineEditorInput);
+            focusInlineEditorRequested = false;
         }
     }
 
@@ -479,6 +481,7 @@ else
         currentEdit = TransactionEdit.FromTransaction(transaction, editCurrentTransaction: true);
         editColumn = column;
         inlineEditorStyle = null;
+        focusInlineEditorRequested = column != EditColumn.Category;
 
         var rect = await JSRuntime.InvokeAsync<BoundingClientRect>("MoneizGetElementDocumentRectById", GetInlineEditorCellId(transaction, column));
         inlineEditorStyle = FormattableString.Invariant($"top: {rect.Top}px; left: {rect.Left}px; min-width: {rect.Width}px;");
@@ -496,6 +499,7 @@ else
         {
             currentEdit = null;
             inlineEditorStyle = null;
+            focusInlineEditorRequested = false;
         }
         else if (e.Key == "Enter" && editColumn != EditColumn.Category)
         {
@@ -512,6 +516,7 @@ else
             await DatabaseProvider.Save();
             currentEdit = null;
             inlineEditorStyle = null;
+            focusInlineEditorRequested = false;
             LoadTransactions();
         }
     }

--- a/src/Meziantou.Moneiz/Shared/InputSelectFilterable.razor
+++ b/src/Meziantou.Moneiz/Shared/InputSelectFilterable.razor
@@ -1,13 +1,11 @@
 @using Microsoft.AspNetCore.Components.Forms
 @typeparam TItem where TItem : class
 @inherits InputBase<TItem?>
-@inject IJSRuntime JS
 
 <input type="hidden" value="@CurrentValueAsString" />
 
 <div class="@ComponentCssClass @CssClass @(_isOpen ? "is-open" : "")" @attributes="AdditionalAttributes">
     <div class="@($"{ComponentCssClass}-control")"
-         @ref="_control"
          @onclick="ToggleDropdown"
          tabindex="0"
          @onkeydown="OnControlKeyDown">
@@ -19,7 +17,7 @@
 
     @if (_isOpen)
     {
-        <div class="@($"{ComponentCssClass}-dropdown")" style="@_dropdownStyle" @ref="_dropdown">
+        <div class="@($"{ComponentCssClass}-dropdown")" @ref="_dropdown">
             <div class="@($"{ComponentCssClass}-search")">
                 <input type="text"
                        class="@($"{ComponentCssClass}-search-input")"
@@ -89,12 +87,10 @@
 @code {
     private bool _isOpen;
     private string _searchText = string.Empty;
-    private ElementReference _control;
     private ElementReference _searchInput;
     private ElementReference _dropdown;
     private List<TItem>? _filteredItems;
     private int _highlightedIndex = -1;
-    private string? _dropdownStyle;
 
     [Parameter, EditorRequired]
     public required IEnumerable<TItem> Items { get; set; }
@@ -153,7 +149,7 @@
         return false;
     }
 
-    private async Task ToggleDropdown()
+    private void ToggleDropdown()
     {
         _isOpen = !_isOpen;
         if (_isOpen)
@@ -162,13 +158,6 @@
             FilterItems();
             _highlightedIndex = CurrentValue is not null ?
                 (_filteredItems?.FindIndex(i => AreItemsEqual(i, CurrentValue)) ?? -1) : -1;
-
-            var rect = await JS.InvokeAsync<DropdownPosition>("MoneizGetBoundingClientRect", _control);
-            _dropdownStyle = FormattableString.Invariant($"position: fixed; top: {rect.Bottom}px; left: {rect.Left}px; width: {rect.Width}px; right: auto;");
-        }
-        else
-        {
-            _dropdownStyle = null;
         }
     }
 
@@ -264,7 +253,7 @@
     {
         if (e.Key == "Enter" || e.Key == " ")
         {
-            await ToggleDropdown();
+            ToggleDropdown();
         }
         else if (_isOpen)
         {
@@ -276,7 +265,6 @@
     {
         await Task.Delay(200);
         _isOpen = false;
-        _dropdownStyle = null;
         StateHasChanged();
     }
 
@@ -297,6 +285,4 @@
 
         return displayName;
     }
-
-    private sealed record DropdownPosition(double Bottom, double Left, double Width);
 }

--- a/src/Meziantou.Moneiz/Shared/InputSelectFilterable.razor
+++ b/src/Meziantou.Moneiz/Shared/InputSelectFilterable.razor
@@ -1,13 +1,15 @@
 @using Microsoft.AspNetCore.Components.Forms
 @typeparam TItem where TItem : class
 @inherits InputBase<TItem?>
+@inject IJSRuntime JS
 
 <input type="hidden" value="@CurrentValueAsString" />
 
 <div class="@ComponentCssClass @CssClass @(_isOpen ? "is-open" : "")" @attributes="AdditionalAttributes">
-    <div class="@($"{ComponentCssClass}-control")" 
-         @onclick="ToggleDropdown" 
-         tabindex="0" 
+    <div class="@($"{ComponentCssClass}-control")"
+         @ref="_control"
+         @onclick="ToggleDropdown"
+         tabindex="0"
          @onkeydown="OnControlKeyDown">
         <span class="@($"{ComponentCssClass}-value")">
             @GetDisplayText(CurrentValue)
@@ -17,7 +19,7 @@
 
     @if (_isOpen)
     {
-        <div class="@($"{ComponentCssClass}-dropdown")" @ref="_dropdown">
+        <div class="@($"{ComponentCssClass}-dropdown")" style="@_dropdownStyle" @ref="_dropdown">
             <div class="@($"{ComponentCssClass}-search")">
                 <input type="text"
                        class="@($"{ComponentCssClass}-search-input")"
@@ -87,10 +89,12 @@
 @code {
     private bool _isOpen;
     private string _searchText = string.Empty;
+    private ElementReference _control;
     private ElementReference _searchInput;
     private ElementReference _dropdown;
     private List<TItem>? _filteredItems;
     private int _highlightedIndex = -1;
+    private string? _dropdownStyle;
 
     [Parameter, EditorRequired]
     public required IEnumerable<TItem> Items { get; set; }
@@ -149,15 +153,22 @@
         return false;
     }
 
-    private void ToggleDropdown()
+    private async Task ToggleDropdown()
     {
         _isOpen = !_isOpen;
         if (_isOpen)
         {
             _searchText = string.Empty;
             FilterItems();
-            _highlightedIndex = CurrentValue is not null ? 
+            _highlightedIndex = CurrentValue is not null ?
                 (_filteredItems?.FindIndex(i => AreItemsEqual(i, CurrentValue)) ?? -1) : -1;
+
+            var rect = await JS.InvokeAsync<DropdownPosition>("MoneizGetBoundingClientRect", _control);
+            _dropdownStyle = FormattableString.Invariant($"position: fixed; top: {rect.Bottom}px; left: {rect.Left}px; width: {rect.Width}px; right: auto;");
+        }
+        else
+        {
+            _dropdownStyle = null;
         }
     }
 
@@ -253,7 +264,7 @@
     {
         if (e.Key == "Enter" || e.Key == " ")
         {
-            ToggleDropdown();
+            await ToggleDropdown();
         }
         else if (_isOpen)
         {
@@ -265,6 +276,7 @@
     {
         await Task.Delay(200);
         _isOpen = false;
+        _dropdownStyle = null;
         StateHasChanged();
     }
 
@@ -285,4 +297,6 @@
 
         return displayName;
     }
+
+    private sealed record DropdownPosition(double Bottom, double Left, double Width);
 }

--- a/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
@@ -73,7 +73,12 @@
     z-index: 1;
   }
 
-.inline-category-editor-overlay {
-  position: fixed;
+.inline-editor-overlay {
+  position: absolute;
   z-index: 2000;
+}
+
+.inline-editor-overlay input {
+  box-sizing: border-box;
+  width: 100%;
 }

--- a/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_page-transactions.css
@@ -72,3 +72,8 @@
     position: relative;
     z-index: 1;
   }
+
+.inline-category-editor-overlay {
+  position: fixed;
+  z-index: 2000;
+}

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -1211,6 +1211,11 @@ body {
     position: relative;
     z-index: 1;
   }
+
+.inline-category-editor-overlay {
+  position: fixed;
+  z-index: 2000;
+}
 .site-sidebar {
     background: var(--hover-bg);
     border-radius: 8px;

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -1212,9 +1212,14 @@ body {
     z-index: 1;
   }
 
-.inline-category-editor-overlay {
-  position: fixed;
+.inline-editor-overlay {
+  position: absolute;
   z-index: 2000;
+}
+
+.inline-editor-overlay input {
+  box-sizing: border-box;
+  width: 100%;
 }
 .site-sidebar {
     background: var(--hover-bg);

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -87,6 +87,11 @@ function MoneizReleaseTrapEnterKey(element) {
   delete element.moneizTrapEnterKey;
 }
 
+function MoneizGetBoundingClientRect(element) {
+    const rect = element.getBoundingClientRect();
+    return { bottom: rect.bottom, left: rect.left, width: rect.width };
+}
+
 (function () {
   let state = false;
 

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -97,6 +97,14 @@ function MoneizGetElementDocumentRectById(id) {
   };
 }
 
+function MoneizFocusIfConnected(element) {
+  if (!element || !element.isConnected) {
+    return;
+  }
+
+  element.focus();
+}
+
 (function () {
   let state = false;
 

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -87,9 +87,10 @@ function MoneizReleaseTrapEnterKey(element) {
   delete element.moneizTrapEnterKey;
 }
 
-function MoneizGetBoundingClientRect(element) {
-    const rect = element.getBoundingClientRect();
-    return { bottom: rect.bottom, left: rect.left, width: rect.width };
+function MoneizGetBoundingClientRectById(id) {
+  const element = document.getElementById(id);
+  const rect = element.getBoundingClientRect();
+  return { bottom: rect.bottom, left: rect.left, width: rect.width };
 }
 
 (function () {

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -87,10 +87,14 @@ function MoneizReleaseTrapEnterKey(element) {
   delete element.moneizTrapEnterKey;
 }
 
-function MoneizGetBoundingClientRectById(id) {
+function MoneizGetElementDocumentRectById(id) {
   const element = document.getElementById(id);
   const rect = element.getBoundingClientRect();
-  return { bottom: rect.bottom, left: rect.left, width: rect.width };
+  return {
+    top: rect.top + window.scrollY,
+    left: rect.left + window.scrollX,
+    width: rect.width,
+  };
 }
 
 (function () {


### PR DESCRIPTION
In tables with `border-collapse: collapse`, browsers clip `position: absolute` children of table cells even when `overflow: visible` is set on the cell. This caused the dropdown in the inline category editor to be hidden when double-clicking a category cell to edit it.

The fix changes `InputSelectFilterable` to open its dropdown using `position: fixed` with viewport-relative coordinates, so the panel escapes all overflow constraints regardless of where the component is mounted.

**Changes:**
- `InputSelectFilterable.razor`: injected `IJSRuntime`, added a `@ref` on the control div, made `ToggleDropdown` async. On open, it calls `MoneizGetBoundingClientRect()` to read the control's bounding rect and applies an inline style with `position: fixed; top/left/width` to the dropdown panel.
- `interop.js`: added `MoneizGetBoundingClientRect(element)` that returns `{ bottom, left, width }` from `getBoundingClientRect()`.