### PR TITLE
Add inline category creation in transaction editor

### DIFF
--- a/src/Meziantou.Moneiz/Extensions/NavigationManagerExtensions.cs
+++ b/src/Meziantou.Moneiz/Extensions/NavigationManagerExtensions.cs
@@ -11,6 +11,17 @@ public static class NavigationManagerExtensions
     public static void NavigateToCategories(this NavigationManager navigationManager) => navigationManager.NavigateTo("categories");
     public static void NavigateToPayees(this NavigationManager navigationManager) => navigationManager.NavigateTo("payees");
     public static void NavigateToScheduler(this NavigationManager navigationManager) => navigationManager.NavigateTo("scheduler");
+    public static void NavigateToReturnUrlOrCategories(this NavigationManager navigationManager)
+    {
+        if (navigationManager.TryGetQueryString("returnUrl", out string? url))
+        {
+            navigationManager.NavigateTo(url);
+        }
+        else
+        {
+            navigationManager.NavigateToCategories();
+        }
+    }
 
     public static void NavigateToReturnUrlOrHome(this NavigationManager navigationManager)
     {

--- a/src/Meziantou.Moneiz/Pages/Categories/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/Categories/Edit.razor
@@ -76,7 +76,7 @@
 
         database.SaveCategory(category);
         await DatabaseProvider.Save();
-        NavigationManager.NavigateToCategories();
+        NavigationManager.NavigateToReturnUrlOrCategories();
     }
 
     private sealed class EditModel

--- a/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
@@ -58,9 +58,43 @@
 		<div class="form-group">
 			<label>
 				Category
-				<InputSelectCategory IsOptional="true" @bind-Value="model.Category" />
+				@if (!_isQuickCreateCategoryVisible)
+				{
+					<InputSelectCategory IsOptional="true" @bind-Value="model.Category" />
+				}
 			</label>
+			<button type="button" class="btn-link" @onclick="ToggleQuickCreateCategory">@(_isQuickCreateCategoryVisible ? "Cancel category creation" : "Create category")</button>
 		</div>
+
+		@if (_isQuickCreateCategoryVisible)
+		{
+			<div class="form-group">
+				<label>
+					Category group
+					<InputText @bind-Value="_quickCreateCategoryGroupName" list="categorygroups-quick-create" />
+					<datalist id="categorygroups-quick-create">
+						@foreach (var group in database!.CategoryGroups.OrderBy(item => item))
+						{
+							<option>@group</option>
+						}
+					</datalist>
+				</label>
+			</div>
+
+			<div class="form-group">
+				<label>
+					Category name
+					<InputText @bind-Value="_quickCreateCategoryName" />
+				</label>
+
+				@if (_quickCreateCategoryErrorMessage is not null)
+				{
+					<div class="validation-message">@_quickCreateCategoryErrorMessage</div>
+				}
+
+				<button type="button" class="btn-link" @onclick="CreateCategory">Save category</button>
+			</div>
+		}
 
 		<div class="form-group">
 			<label>
@@ -94,6 +128,10 @@
 @code {
 	Database? database;
 	TransactionEdit? model;
+	string? _quickCreateCategoryName;
+	string? _quickCreateCategoryGroupName;
+	string? _quickCreateCategoryErrorMessage;
+	bool _isQuickCreateCategoryVisible;
 
 	[Parameter]
 	public int? Id { get; set; }
@@ -129,10 +167,75 @@
 	{
 		Debug.Assert(database != null);
 		Debug.Assert(model != null);
+		if (!await EnsureQuickCreatedCategoryAssigned(displayErrors: false))
+		{
+			return;
+		}
 
 		model.Save(database);
 		await DatabaseProvider.Save();
 		NavigationManager.NavigateToReturnUrlOrHome();
+	}
+
+	private void ToggleQuickCreateCategory()
+	{
+		_isQuickCreateCategoryVisible = !_isQuickCreateCategoryVisible;
+		_quickCreateCategoryErrorMessage = null;
+	}
+
+	private async Task CreateCategory()
+	{
+		if (!await EnsureQuickCreatedCategoryAssigned(displayErrors: true))
+		{
+			return;
+		}
+
+		_quickCreateCategoryName = null;
+		_quickCreateCategoryGroupName = null;
+		_quickCreateCategoryErrorMessage = null;
+		_isQuickCreateCategoryVisible = false;
+	}
+
+	private async Task<bool> EnsureQuickCreatedCategoryAssigned(bool displayErrors)
+	{
+		Debug.Assert(database != null);
+		Debug.Assert(model != null);
+
+		if (!_isQuickCreateCategoryVisible)
+		{
+			return true;
+		}
+
+		var categoryName = _quickCreateCategoryName.TrimAndNullify();
+		if (categoryName is null)
+		{
+			if (displayErrors)
+			{
+				_quickCreateCategoryErrorMessage = "Category name is required";
+			}
+
+			return true;
+		}
+
+		var categoryGroupName = _quickCreateCategoryGroupName.TrimAndNullify();
+		var category = database.Categories.FirstOrDefault(item =>
+			string.Equals(item.Name, categoryName, StringComparison.Ordinal) &&
+			string.Equals(item.GroupName, categoryGroupName, StringComparison.Ordinal));
+
+		if (category is null)
+		{
+			category = new Category
+			{
+				Name = categoryName,
+				GroupName = categoryGroupName,
+			};
+
+			database.SaveCategory(category);
+			await DatabaseProvider.Save();
+		}
+
+		model.Category = category;
+		return true;
 	}
 
 	private void OnPayeeChanged()


### PR DESCRIPTION
This change removes the context switch when a transaction needs a new category. Users can now create and assign a category directly in the transaction create/edit form.

## What changed
- Added an inline "Create category" flow in `Transactions/Edit.razor`.
- When quick-create is enabled, the existing category dropdown is hidden.
- Added inline inputs for category group and category name, with validation for required category name.
- Saving an inline category reuses an existing `(GroupName, Name)` match or creates a new category, then assigns it to the transaction model.
- On transaction submit, quick-create data is also resolved so the transaction is saved with the created/selected category.
- Updated category page navigation to support return-url behavior when needed (`NavigateToReturnUrlOrCategories`).

## Notes
- The category edit page now returns to `returnUrl` when present, otherwise back to categories.
- This keeps category creation behavior consistent with transaction-driven flows.