### PR TITLE
Add configurable category labels in transaction and payee tables

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Payees/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Payees/Index.razor
@@ -40,7 +40,7 @@
 				var payee = payeeRow.Payee;
 			}
 			<td>@payee</td>
-			<td>@payee.DefaultCategory</td>
+			<td>@FormatCategory(payee.DefaultCategory)</td>
 			<td style="text-align: right">@payeeRow.TransactionCount</td>
 			<td class="commands">
 				<Dropdown>
@@ -55,12 +55,14 @@
 
 @code {
 	Database? database;
+	MoneizDisplaySettings displaySettings = new();
 	SortColumn sortColumn = SortColumn.Name;
 	bool sortAscending = true;
 
 	protected override async Task OnInitializedAsync()
 	{
 		database = await DatabaseProvider.GetDatabase();
+		displaySettings = await SettingsProvider.GetDisplaySettings();
 	}
 
 	private IEnumerable<PayeeRow>? SortedPayees
@@ -105,7 +107,7 @@
 		return sortColumn switch
 		{
 			SortColumn.Name => SortBy(payees, payee => payee.Payee.Name),
-			SortColumn.DefaultCategory => SortBy(payees, payee => payee.Payee.DefaultCategory?.Name),
+			SortColumn.DefaultCategory => SortBy(payees, payee => FormatCategory(payee.Payee.DefaultCategory)),
 			SortColumn.Transactions => sortAscending
 				? payees.OrderBy(payee => payee.TransactionCount).ThenBy(payee => payee.Payee.Name, StringComparer.OrdinalIgnoreCase)
 				: payees.OrderByDescending(payee => payee.TransactionCount).ThenBy(payee => payee.Payee.Name, StringComparer.OrdinalIgnoreCase),
@@ -127,6 +129,9 @@
 
 		return sortAscending ? " ↑" : " ↓";
 	}
+
+	private string? FormatCategory(Category? category)
+		=> displaySettings.FormatCategory(category);
 
 	private enum SortColumn
 	{

--- a/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
+++ b/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
@@ -30,6 +30,16 @@
         </label>
     </div>
 
+    <div class="form-group">
+        <label>
+            Category display
+            <InputSelect @bind-Value="displaySettings.CategoryDisplayMode">
+                <option value="@CategoryDisplayMode.Name">Show category name</option>
+                <option value="@CategoryDisplayMode.FullName">Show full category name (group::category)</option>
+            </InputSelect>
+        </label>
+    </div>
+
     <button type="submit">Save</button>
 </EditForm>
 

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -150,7 +150,7 @@ else
                         }
                         else
                         {
-                            @transaction.Category?.Name
+                            @FormatCategory(transaction.Category)
                         }
                     </td>
                     <td title="@transaction.FinalTitle">@transaction.FinalTitle</td>
@@ -261,7 +261,7 @@ else
 
 
 @code {
-    MoneizDisplaySettings? displaySettings;
+    MoneizDisplaySettings displaySettings = new();
     Database? database;
     Account? account;
     List<TransactionWithAccountBalance>? transactions;
@@ -442,7 +442,7 @@ else
         result = result.OrderByDescending(t => t.ValueDate).ThenByDescending(t => t.Id);
 
         // Load the transactions we need
-        var list = new List<TransactionWithAccountBalance>(capacity: displaySettings!.PageSize);
+        var list = new List<TransactionWithAccountBalance>(capacity: displaySettings.PageSize);
         var balance = CanShowAccountBalanceOnTransaction && account != null ? database.GetBalance(account) : 0m;
         using var enumerator = result.GetEnumerator();
 
@@ -528,6 +528,9 @@ else
 
         return defaultValue;
     }
+
+    private string? FormatCategory(Category? category)
+        => displaySettings.FormatCategory(category);
 
     private enum EditColumn
     {

--- a/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
+++ b/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
@@ -1,6 +1,14 @@
 ﻿#nullable enable
 
+using Meziantou.Moneiz.Core;
+
 namespace Meziantou.Moneiz.Services;
+
+public enum CategoryDisplayMode
+{
+    Name,
+    FullName,
+}
 
 public class MoneizDisplaySettings
 {
@@ -9,9 +17,24 @@ public class MoneizDisplaySettings
     public bool FullWidth { get; set; }
     public bool SidebarCollapsed { get; set; }
     public int? SidebarMaxWidth { get; set; } = 400;
+    public CategoryDisplayMode CategoryDisplayMode { get; set; } = CategoryDisplayMode.Name;
 
     public string FormatDate(DateOnly date) => DateFormat is null ? date.ToShortDateString() : date.ToString(DateFormat, CultureInfo.InvariantCulture);
     public string? FormatDate(DateOnly? date) => DateFormat is null ? date?.ToShortDateString() : date?.ToString(DateFormat, CultureInfo.InvariantCulture);
     public string FormatDate(DateTime date) => DateFormat is null ? date.ToShortDateString() : date.ToString(DateFormat, CultureInfo.InvariantCulture);
     public string? FormatDate(DateTime? date) => DateFormat is null ? date?.ToShortDateString() : date?.ToString(DateFormat, CultureInfo.InvariantCulture);
+
+    public string? FormatCategory(Category? category)
+    {
+        if (category is null)
+        {
+            return null;
+        }
+
+        return CategoryDisplayMode switch
+        {
+            CategoryDisplayMode.FullName => category.ToString(),
+            _ => category.Name ?? "",
+        };
+    }
 }

--- a/src/Meziantou.Moneiz/Services/SettingsProvider.cs
+++ b/src/Meziantou.Moneiz/Services/SettingsProvider.cs
@@ -19,6 +19,11 @@ public static partial class SettingsProvider
         var result = await GetValue("displaySettings", JsonSettingsContext.Default.MoneizDisplaySettings);
         result ??= new MoneizDisplaySettings();
         result.PageSize = Math.Clamp(result.PageSize, 10, int.MaxValue);
+        if (!Enum.IsDefined(typeof(CategoryDisplayMode), result.CategoryDisplayMode))
+        {
+            result.CategoryDisplayMode = CategoryDisplayMode.Name;
+        }
+
         if (string.IsNullOrWhiteSpace(result.DateFormat))
         {
             result.DateFormat = null;


### PR DESCRIPTION
This adds a display setting so users can choose how category names appear in tables without affecting editing workflows.

## What changed
- Added a new display option in **Settings > Display**:
  - `Show category name` (default)
  - `Show full category name (group::category)`
- Persisted the setting in `MoneizDisplaySettings` (`CategoryDisplayMode`) and normalized legacy/invalid values in `SettingsProvider`.
- Applied the setting only to table rendering:
  - Transactions list category cell
  - Payees list default-category cell (and related sorting key)

## Intentional scope
- Editors/selectors were left unchanged.
- Categories page remains unchanged and continues to show full values.