### PR TITLE
Add sortable columns to transactions list

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -77,19 +77,43 @@ else
         <thead>
             <tr>
                 <th></th>
-                <th>Operation Date</th>
+                <th>
+                    <a href="@GetSortUri(SortColumn.OperationDate)">
+                        Operation Date @GetSortIndicator(SortColumn.OperationDate)
+                    </a>
+                </th>
                 @if (AccountId is null)
                 {
-                    <th>Account</th>
+                    <th>
+                        <a href="@GetSortUri(SortColumn.Account)">
+                            Account @GetSortIndicator(SortColumn.Account)
+                        </a>
+                    </th>
                 }
-                <th>Category</th>
-                <th>Title</th>
-                <th>Amount</th>
+                <th>
+                    <a href="@GetSortUri(SortColumn.Category)">
+                        Category @GetSortIndicator(SortColumn.Category)
+                    </a>
+                </th>
+                <th>
+                    <a href="@GetSortUri(SortColumn.Title)">
+                        Title @GetSortIndicator(SortColumn.Title)
+                    </a>
+                </th>
+                <th>
+                    <a href="@GetSortUri(SortColumn.Amount)">
+                        Amount @GetSortIndicator(SortColumn.Amount)
+                    </a>
+                </th>
                 @if (CanShowAccountBalanceOnTransaction)
                 {
                     <th>Balance</th>
                 }
-                <th>Comment</th>
+                <th>
+                    <a href="@GetSortUri(SortColumn.Comment)">
+                        Comment @GetSortIndicator(SortColumn.Comment)
+                    </a>
+                </th>
                 <th></th>
             </tr>
         </thead>
@@ -291,6 +315,12 @@ else
     [Parameter, SupplyParameterFromQuery(Name = "page")]
     public int? PageIndex { get; set; }
 
+    [Parameter, SupplyParameterFromQuery(Name = "sort")]
+    public string? Sort { get; set; }
+
+    [Parameter, SupplyParameterFromQuery(Name = "asc")]
+    public bool? SortAscending { get; set; }
+
     protected override async Task OnInitializedAsync()
     {
         displaySettings = await SettingsProvider.GetDisplaySettings();
@@ -301,6 +331,7 @@ else
     protected override async Task OnParametersSetAsync()
     {
         PageIndex ??= 0;
+        SetSortOptionsFromQuery();
 
         if (AccountId != null)
         {
@@ -308,7 +339,14 @@ else
         }
 
         HasSearch = !string.IsNullOrWhiteSpace(Search);
-        CanShowAccountBalanceOnTransaction = AccountId is not null && CategoryId is null && CategoryGroup is null && PayeeId is null && !HasSearch;
+        CanShowAccountBalanceOnTransaction =
+            AccountId is not null &&
+            CategoryId is null &&
+            CategoryGroup is null &&
+            PayeeId is null &&
+            !HasSearch &&
+            sortColumn is SortColumn.OperationDate &&
+            !sortAscending;
         LoadTransactions();
     }
 
@@ -330,6 +368,9 @@ else
     private bool HasMorePages { get; set; }
 
     private bool ShowReconciledTransactions() => showReconciled || HasSearch;
+
+    private SortColumn sortColumn = SortColumn.OperationDate;
+    private bool sortAscending;
 
     private async Task ToggleReconciledVisibility()
     {
@@ -439,7 +480,7 @@ else
             result = result.Where(t => query.Evaluate(t));
         }
 
-        result = result.OrderByDescending(t => t.ValueDate).ThenByDescending(t => t.Id);
+        result = GetSortedTransactions(result);
 
         // Load the transactions we need
         var list = new List<TransactionWithAccountBalance>(capacity: displaySettings!.PageSize);
@@ -474,6 +515,111 @@ else
         HasMorePages = enumerator.MoveNext();
 
         Console.WriteLine($"LoadTransactions: {sw.ElapsedMilliseconds}ms");
+    }
+
+    private IEnumerable<Transaction> GetSortedTransactions(IEnumerable<Transaction> transactions)
+    {
+        return (sortColumn, sortAscending) switch
+        {
+            (SortColumn.OperationDate, true) => transactions.OrderBy(t => t.ValueDate).ThenBy(t => t.Id),
+            (SortColumn.Account, true) => transactions.OrderBy(t => t.Account?.ToString(), StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Category, true) => transactions.OrderBy(t => t.Category?.Name, StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Title, true) => transactions.OrderBy(t => t.FinalTitle, StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Amount, true) => transactions.OrderBy(t => t.Amount).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Comment, true) => transactions.OrderBy(t => t.Comment, StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+
+            (SortColumn.OperationDate, false) => transactions.OrderByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Account, false) => transactions.OrderByDescending(t => t.Account?.ToString(), StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Category, false) => transactions.OrderByDescending(t => t.Category?.Name, StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Title, false) => transactions.OrderByDescending(t => t.FinalTitle, StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Amount, false) => transactions.OrderByDescending(t => t.Amount).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+            (SortColumn.Comment, false) => transactions.OrderByDescending(t => t.Comment, StringComparer.CurrentCultureIgnoreCase).ThenByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+
+            _ => transactions.OrderByDescending(t => t.ValueDate).ThenByDescending(t => t.Id),
+        };
+    }
+
+    private string GetSortUri(SortColumn column)
+    {
+        var newSortAscending = sortColumn == column ? !sortAscending : GetDefaultSortAscending(column);
+        return NavigationManager.GetUriWithQueryParameters(new Dictionary<string, object?>
+        {
+            ["sort"] = GetSortQueryValue(column),
+            ["asc"] = newSortAscending,
+            ["page"] = 0,
+        });
+    }
+
+    private string GetSortIndicator(SortColumn column)
+    {
+        if (sortColumn != column)
+            return "";
+
+        return sortAscending ? "▲" : "▼";
+    }
+
+    private void SetSortOptionsFromQuery()
+    {
+        if (!TryParseSortColumn(Sort, out var parsedSortColumn))
+        {
+            sortColumn = SortColumn.OperationDate;
+            sortAscending = false;
+            return;
+        }
+
+        sortColumn = parsedSortColumn;
+        sortAscending = SortAscending ?? GetDefaultSortAscending(parsedSortColumn);
+    }
+
+    private static bool TryParseSortColumn(string? value, out SortColumn column)
+    {
+        switch (value?.ToLowerInvariant())
+        {
+            case "date":
+                column = SortColumn.OperationDate;
+                return true;
+            case "account":
+                column = SortColumn.Account;
+                return true;
+            case "category":
+                column = SortColumn.Category;
+                return true;
+            case "title":
+                column = SortColumn.Title;
+                return true;
+            case "amount":
+                column = SortColumn.Amount;
+                return true;
+            case "comment":
+                column = SortColumn.Comment;
+                return true;
+            default:
+                column = default;
+                return false;
+        }
+    }
+
+    private static string GetSortQueryValue(SortColumn column)
+    {
+        return column switch
+        {
+            SortColumn.OperationDate => "date",
+            SortColumn.Account => "account",
+            SortColumn.Category => "category",
+            SortColumn.Title => "title",
+            SortColumn.Amount => "amount",
+            SortColumn.Comment => "comment",
+            _ => "date",
+        };
+    }
+
+    private static bool GetDefaultSortAscending(SortColumn column)
+    {
+        return column switch
+        {
+            SortColumn.OperationDate => false,
+            _ => true,
+        };
     }
 
     private async Task BeginInlineEdit(Transaction transaction, EditColumn column)
@@ -535,6 +681,16 @@ else
         Comment,
         Date,
         Category,
+    }
+
+    private enum SortColumn
+    {
+        OperationDate,
+        Account,
+        Category,
+        Title,
+        Amount,
+        Comment,
     }
 
     private record struct TransactionWithAccountBalance(Transaction Transaction, decimal AccountBalanceAfterTransaction);


### PR DESCRIPTION
Transactions page needed interactive sorting so users can quickly reorder rows by the field they are inspecting, not only by date.

## What changed
- Added clickable headers on the transactions table for Operation Date, Account, Category, Title, Amount, and Comment.
- Implemented asc/desc toggling when clicking the same header repeatedly.
- Persisted sort state in query parameters (`sort`, `asc`) so sorting is shareable/bookmarkable.
- Kept date descending as the default behavior when no sort is specified.
- Reset pagination to page 0 when changing sort to avoid inconsistent paging.
- Kept account running balance visible only in the original default order (date desc), where it remains meaningful.

## Notes for reviewers
- Sorting uses column-specific comparers and keeps deterministic tie-breakers via date/id ordering.