### PR TITLE
Use available screen height for filterable select popups

### DIFF
--- a/src/Meziantou.Moneiz/wwwroot/css/_input-select-account.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_input-select-account.css
@@ -69,7 +69,8 @@
   left: 0;
   right: 0;
   z-index: 1000;
-  max-height: 300px;
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -106,8 +107,9 @@
 
 /* Options List */
 .input-select-account-options {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  max-height: 250px;
 }
 
 /* Group Header (Bank Name) */

--- a/src/Meziantou.Moneiz/wwwroot/css/_input-select-category.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_input-select-category.css
@@ -69,7 +69,8 @@
   left: 0;
   right: 0;
   z-index: 1000;
-  max-height: 300px;
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -106,8 +107,9 @@
 
 /* Options List */
 .input-select-category-options {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  max-height: 250px;
 }
 
 /* Group Header */

--- a/src/Meziantou.Moneiz/wwwroot/css/_input-select-filterable.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_input-select-filterable.css
@@ -64,7 +64,8 @@
   left: 0;
   right: 0;
   z-index: 1000;
-  max-height: 300px;
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -101,8 +102,9 @@
 
 /* Options List */
 .input-select-filterable-options {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  max-height: 250px;
 }
 
 /* Group Header */

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -501,7 +501,8 @@ button[type=submit] {
   left: 0;
   right: 0;
   z-index: 1000;
-  max-height: 300px;
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -538,8 +539,9 @@ button[type=submit] {
 
 /* Options List */
 .input-select-account-options {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  max-height: 250px;
 }
 
 /* Group Header (Bank Name) */
@@ -689,7 +691,8 @@ button[type=submit] {
   left: 0;
   right: 0;
   z-index: 1000;
-  max-height: 300px;
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -726,8 +729,9 @@ button[type=submit] {
 
 /* Options List */
 .input-select-category-options {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  max-height: 250px;
 }
 
 /* Group Header */
@@ -872,7 +876,8 @@ button[type=submit] {
   left: 0;
   right: 0;
   z-index: 1000;
-  max-height: 300px;
+  max-height: calc(100vh - 2rem);
+  max-height: calc(100dvh - 2rem);
   background-color: var(--bg-color);
   border: 1px solid var(--border-color);
   border-top: none;
@@ -909,8 +914,9 @@ button[type=submit] {
 
 /* Options List */
 .input-select-filterable-options {
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
-  max-height: 250px;
 }
 
 /* Group Header */


### PR DESCRIPTION
Filterable select popups were capped by fixed heights, so they stayed small even on large screens and showed unnecessary scrolling.

This updates all filterable select variants (`input-select-account`, `input-select-category`, and `input-select-filterable`) to use viewport-based max height instead of fixed pixel limits.

- Replaced fixed dropdown max-height values with `calc(100vh - 2rem)` and `calc(100dvh - 2rem)` fallback/override.
- Removed fixed option-list max heights and made the list a flexible scroll container (`flex: 1 1 auto; min-height: 0; overflow-y: auto`).
- Kept bundled CSS in sync by committing the regenerated `wwwroot/css/site.css` output.

This keeps the same interaction model (search + scrolling list) while allowing the popup to grow much larger when space is available.