### PR TITLE
Document search query language and add in-search help link

### DIFF
--- a/doc/search-query-language.md
+++ b/doc/search-query-language.md
@@ -1,0 +1,72 @@
+# Search query language
+
+This page documents the search query language for each search box in the app.
+
+## Transactions search box
+
+Applies to:
+
+- `/transactions`
+- `/accounts/{id}/transactions`
+- `/categories/{id}/transactions`
+- `/category-group/{group}/transactions`
+- `/payees/{id}/transactions`
+
+### Syntax
+
+- **Text query**: `groceries`
+- **Field query**: `field:value`
+- **Comparison operators**: `:`, `=`, `<>`, `<`, `<=`, `>`, `>=`
+- **Boolean operators**: `AND`, `OR`, `NOT`
+- **Grouping**: parentheses `(...)`
+- **Quoted values**: `"..."` for values with spaces
+
+### Supported fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `bank` | text | Account bank name |
+| `account` | text | Account name |
+| `accountId` | number | Account id |
+| `title` | text | Transaction title |
+| `payee` | text | Payee name |
+| `category` | text | Category name |
+| `categoryGroup` | text | Category group name |
+| `comment` | text | Transaction comment |
+| `state` | enum | `NotChecked`, `Checked`, `Reconciliated` |
+| `date` | date | Transaction date (`yyyy-MM-dd`) |
+| `amount` | number | Transaction amount |
+
+### Free text behavior
+
+A query without a field name searches in:
+
+- `title`
+- `payee`
+- `category`
+- `categoryGroup`
+- `comment`
+
+If the text contains a decimal number token formatted like an amount (for example `12.00`), it can also match transactions with the exact same `amount`.
+
+### Examples
+
+```text
+groceries
+```
+
+```text
+title:"Monthly rent" AND amount<0
+```
+
+```text
+date>=2026-01-01 AND date<=2026-01-31
+```
+
+```text
+NOT (state=Reconciliated OR categoryGroup:"Internal transfer")
+```
+
+```text
+accountId=3 AND payee:"Coffee shop"
+```

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -64,6 +64,9 @@ else
 
 <div class="input-group mb-3">
     <input type="text" value="@Search" @oninput="OnSearch" class="form-control" placeholder="🔍 Search">
+    <div class="input-group-append">
+        <a class="input-group-text" href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-query-language.md" target="_blank" title="Search query language help">?</a>
+    </div>
 </div>
 
 

--- a/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor
+++ b/src/Meziantou.Moneiz/Shared/ApplicationVersion.razor
@@ -10,7 +10,7 @@
 		<a href="javascript:MoneizUpdate()"><i class="fas fa-sync"></i> Force update</a>
 	}
 
-	<a href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-syntax.md" target="_blank"><i class="fa fa-question-circle"></i> Help</a>
+	<a href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-query-language.md" target="_blank"><i class="fa fa-question-circle"></i> Help</a>
 	<a href="https://github.com/meziantou/meziantou.moneiz/issues" target="_blank"><i class="fas fa-lightbulb"></i> Suggest features</a>
 	<a href="https://github.com/meziantou/meziantou.moneiz/issues" target="_blank"><i class="fas fa-bug"></i> Report issues</a>
 </p>


### PR DESCRIPTION
## Why
The transaction search syntax was only partially documented and the help entry point was not available where users type queries. This made advanced filters harder to discover and use.

## What changed
- Added a new documentation page at `doc/search-query-language.md`.
  - Documents query syntax, operators, grouping, and quoted values.
  - Lists all supported transaction search fields: `bank`, `account`, `accountId`, `title`, `payee`, `category`, `categoryGroup`, `comment`, `state`, `date`, and `amount`.
  - Documents free-text behavior and provides concrete examples.
- Added a `?` help button next to the transactions search input that opens the new page.
- Updated the existing global Help link to point to the same new documentation page.

## Notes
This change is documentation and discoverability only. Search behavior itself is unchanged.