### PR TITLE
Add transaction labels

### DIFF
--- a/src/Meziantou.Moneiz.Cli/Program.cs
+++ b/src/Meziantou.Moneiz.Cli/Program.cs
@@ -95,6 +95,11 @@ static Command CreateAddTransactionCommand()
         Description = "Mark transaction as checked (optional, default: false)"
     };
 
+    var labelsOption = new Option<string?>("--labels")
+    {
+        Description = "Comma-separated list of labels to assign to the transaction (optional)"
+    };
+
     addTransactionCommand.Options.Add(addFileOption);
     addTransactionCommand.Options.Add(addAccountIdOption);
     addTransactionCommand.Options.Add(toAccountIdOption);
@@ -104,6 +109,7 @@ static Command CreateAddTransactionCommand()
     addTransactionCommand.Options.Add(categoryOption);
     addTransactionCommand.Options.Add(commentOption);
     addTransactionCommand.Options.Add(checkedOption);
+    addTransactionCommand.Options.Add(labelsOption);
 
     addTransactionCommand.SetAction(async (parseResult) =>
     {
@@ -116,6 +122,7 @@ static Command CreateAddTransactionCommand()
         var category = parseResult.GetValue(categoryOption);
         var comment = parseResult.GetValue(commentOption);
         var isChecked = parseResult.GetValue(checkedOption);
+        var labels = parseResult.GetValue(labelsOption);
 
         if (file is null)
         {
@@ -123,7 +130,7 @@ static Command CreateAddTransactionCommand()
             return 1;
         }
 
-        return await AddTransactionAsync(file, accountId, toAccountId, amount, valueDate, payee, category, comment, isChecked);
+        return await AddTransactionAsync(file, accountId, toAccountId, amount, valueDate, payee, category, comment, isChecked, labels);
     });
 
     return addTransactionCommand;
@@ -173,6 +180,11 @@ static Command CreateUpdateTransactionCommand()
         Description = "Mark transaction as checked or unchecked (optional, true/false)"
     };
 
+    var labelsOption = new Option<string?>("--labels")
+    {
+        Description = "Comma-separated list of labels to assign to the transaction. Pass empty string to clear labels."
+    };
+
     updateTransactionCommand.Options.Add(updateFileOption);
     updateTransactionCommand.Options.Add(transactionIdOption);
     updateTransactionCommand.Options.Add(amountOption);
@@ -181,6 +193,7 @@ static Command CreateUpdateTransactionCommand()
     updateTransactionCommand.Options.Add(categoryOption);
     updateTransactionCommand.Options.Add(commentOption);
     updateTransactionCommand.Options.Add(checkedOption);
+    updateTransactionCommand.Options.Add(labelsOption);
 
     updateTransactionCommand.SetAction(async (parseResult) =>
     {
@@ -192,6 +205,7 @@ static Command CreateUpdateTransactionCommand()
         var category = parseResult.GetValue(categoryOption);
         var comment = parseResult.GetValue(commentOption);
         var isChecked = parseResult.GetValue(checkedOption);
+        var labels = parseResult.GetValue(labelsOption);
 
         if (file is null)
         {
@@ -199,7 +213,7 @@ static Command CreateUpdateTransactionCommand()
             return 1;
         }
 
-        return await UpdateTransactionAsync(file, transactionId, amount, valueDate, payee, category, comment, isChecked);
+        return await UpdateTransactionAsync(file, transactionId, amount, valueDate, payee, category, comment, isChecked, labels);
     });
 
     return updateTransactionCommand;
@@ -361,7 +375,7 @@ static string FormatAmount(decimal amount, string? currencyCode)
     return $"{sign}{absAmount:N2} {currencyCode ?? ""}".Trim();
 }
 
-static async Task<int> AddTransactionAsync(FileInfo file, int accountId, int? toAccountId, decimal amount, DateOnly? valueDate, string? payeeName, string? categoryName, string? comment, bool isChecked)
+static async Task<int> AddTransactionAsync(FileInfo file, int accountId, int? toAccountId, decimal amount, DateOnly? valueDate, string? payeeName, string? categoryName, string? comment, bool isChecked, string? labelsString)
 {
     if (!file.Exists)
     {
@@ -445,6 +459,9 @@ static async Task<int> AddTransactionAsync(FileInfo file, int accountId, int? to
         }
     }
 
+    // Parse labels
+    var labels = ParseLabels(labelsString);
+
     // Create and save transaction(s)
     Transaction transaction;
     Transaction? linkedTransaction = null;
@@ -460,7 +477,8 @@ static async Task<int> AddTransactionAsync(FileInfo file, int accountId, int? to
             ValueDate = valueDate.Value,
             Category = category,
             Comment = comment,
-            CheckedDate = isChecked ? Database.GetToday() : null
+            CheckedDate = isChecked ? Database.GetToday() : null,
+            Labels = labels,
         };
 
         // Credit transaction (deposit to destination account)
@@ -471,7 +489,8 @@ static async Task<int> AddTransactionAsync(FileInfo file, int accountId, int? to
             ValueDate = valueDate.Value,
             Category = category,
             Comment = comment,
-            CheckedDate = isChecked ? Database.GetToday() : null
+            CheckedDate = isChecked ? Database.GetToday() : null,
+            Labels = labels,
         };
 
         // Link the transactions
@@ -492,7 +511,8 @@ static async Task<int> AddTransactionAsync(FileInfo file, int accountId, int? to
             Payee = payee,
             Category = category,
             Comment = comment,
-            CheckedDate = isChecked ? Database.GetToday() : null
+            CheckedDate = isChecked ? Database.GetToday() : null,
+            Labels = labels,
         };
 
         db.SaveTransaction(transaction);
@@ -536,13 +556,15 @@ static async Task<int> AddTransactionAsync(FileInfo file, int accountId, int? to
         Console.WriteLine($"  Category: {category}");
     if (!string.IsNullOrWhiteSpace(comment))
         Console.WriteLine($"  Comment: {comment}");
+    if (labels is { Length: > 0 })
+        Console.WriteLine($"  Labels: {string.Join(", ", labels)}");
     if (isChecked)
         Console.WriteLine($"  Status: Checked");
 
     return 0;
 }
 
-static async Task<int> UpdateTransactionAsync(FileInfo file, int transactionId, decimal? amount, DateOnly? valueDate, string? payeeName, string? categoryName, string? comment, bool? isChecked)
+static async Task<int> UpdateTransactionAsync(FileInfo file, int transactionId, decimal? amount, DateOnly? valueDate, string? payeeName, string? categoryName, string? comment, bool? isChecked, string? labelsString)
 {
     if (!file.Exists)
     {
@@ -710,6 +732,18 @@ static async Task<int> UpdateTransactionAsync(FileInfo file, int transactionId, 
         }
     }
 
+    // Update labels if specified (null means not specified; non-null means update — empty string means clear)
+    if (labelsString is not null)
+    {
+        var labels = ParseLabels(labelsString);
+        transaction.Labels = labels;
+        if (isLinkedTransaction)
+        {
+            transaction.LinkedTransaction!.Labels = labels;
+            db.SaveTransaction(transaction.LinkedTransaction!);
+        }
+    }
+
     // Save the updated transaction
     db.SaveTransaction(transaction);
 
@@ -742,6 +776,9 @@ static async Task<int> UpdateTransactionAsync(FileInfo file, int transactionId, 
 
     if (!string.IsNullOrWhiteSpace(transaction.Comment))
         Console.WriteLine($"  Comment: {transaction.Comment}");
+
+    if (transaction.Labels is { Length: > 0 })
+        Console.WriteLine($"  Labels: {string.Join(", ", transaction.Labels)}");
 
     if (transaction.CheckedDate.HasValue)
         Console.WriteLine($"  Status: Checked");
@@ -816,6 +853,11 @@ static Command CreateGetTransactionsCommand()
         Description = "Filter by linked transaction ID"
     };
 
+    var labelOption = new Option<string?>("--label")
+    {
+        Description = "Filter by label name (exact match)"
+    };
+
     getTransactionsCommand.Options.Add(fileOption);
     getTransactionsCommand.Options.Add(accountIdOption);
     getTransactionsCommand.Options.Add(payeeIdOption);
@@ -827,6 +869,7 @@ static Command CreateGetTransactionsCommand()
     getTransactionsCommand.Options.Add(checkedOption);
     getTransactionsCommand.Options.Add(reconciliatedOption);
     getTransactionsCommand.Options.Add(linkedTransactionIdOption);
+    getTransactionsCommand.Options.Add(labelOption);
 
     getTransactionsCommand.SetAction(async (parseResult) =>
     {
@@ -841,6 +884,7 @@ static Command CreateGetTransactionsCommand()
         var isChecked = parseResult.GetValue(checkedOption);
         var isReconciliated = parseResult.GetValue(reconciliatedOption);
         var linkedTransactionId = parseResult.GetValue(linkedTransactionIdOption);
+        var label = parseResult.GetValue(labelOption);
 
         if (file is null)
         {
@@ -859,7 +903,8 @@ static Command CreateGetTransactionsCommand()
             toDate,
             isChecked,
             isReconciliated,
-            linkedTransactionId);
+            linkedTransactionId,
+            label);
     });
 
     return getTransactionsCommand;
@@ -876,7 +921,8 @@ static async Task<int> GetTransactionsAsync(
     DateOnly? toDate,
     bool? isChecked,
     bool? isReconciliated,
-    int? linkedTransactionId)
+    int? linkedTransactionId,
+    string? label)
 {
     if (!file.Exists)
     {
@@ -964,6 +1010,11 @@ static async Task<int> GetTransactionsAsync(
         transactions = transactions.Where(t => t.LinkedTransactionId == linkedTransactionId.Value);
     }
 
+    if (!string.IsNullOrEmpty(label))
+    {
+        transactions = transactions.Where(t => t.Labels is not null && t.Labels.Contains(label, StringComparer.Ordinal));
+    }
+
     // Convert to list for serialization
     var transactionsList = transactions.ToList();
 
@@ -983,6 +1034,7 @@ static async Task<int> GetTransactionsAsync(
         CategoryId = t.CategoryId,
         CategoryName = t.Category?.ToString(),
         LinkedTransactionId = t.LinkedTransactionId,
+        Labels = t.Labels,
         State = t.State.ToString()
     }).ToList();
 
@@ -997,4 +1049,17 @@ static async Task<int> GetTransactionsAsync(
     Console.WriteLine(json);
 
     return 0;
+}
+
+static string[]? ParseLabels(string? labelsString)
+{
+    if (labelsString is null)
+        return null;
+
+    var labels = labelsString
+        .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .Distinct(StringComparer.Ordinal)
+        .ToArray();
+
+    return labels.Length > 0 ? labels : null;
 }

--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsModel.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsModel.cs
@@ -17,12 +17,12 @@ public sealed class AnalyticsModel
             Accounts = accounts,
             PeriodFrom = options.FromDate,
             PeriodTo = options.ToDate,
-            BalanceHistory = BuildBalanceHistory(database, accounts, options.FromDate, options.ToDate),
+            BalanceHistory = BuildBalanceHistory(database, accounts, options.FromDate, options.ToDate, options),
             BigTable = BuildBigTable(database, options),
         };
     }
 
-    private static BalanceHistory BuildBalanceHistory(Database database, IReadOnlyList<Account> accounts, DateOnly fromDate, DateOnly toDate)
+    private static BalanceHistory BuildBalanceHistory(Database database, IReadOnlyList<Account> accounts, DateOnly fromDate, DateOnly toDate, AnalyticsOptions options)
     {
         var result = new BalanceHistory()
         {
@@ -36,7 +36,9 @@ public sealed class AnalyticsModel
 
             var initialBalance = database.GetBalance(account, fromDate.AddDays(-1));
             balances[0] = initialBalance;
-            var transactions = database.Transactions.Where(t => t.Account == account && t.ValueDate >= fromDate && t.ValueDate <= toDate).OrderBy(t => t.ValueDate);
+            var transactions = database.Transactions
+                .Where(t => t.Account == account && t.ValueDate >= fromDate && t.ValueDate <= toDate && options.TransactionMatchesLabelFilter(t))
+                .OrderBy(t => t.ValueDate);
             var currentIndex = 0;
             foreach (var transaction in transactions)
             {
@@ -77,7 +79,7 @@ public sealed class AnalyticsModel
         var dateGrouping = options.BigTableDateGrouping;
 
         var transactionGroups = database.Transactions
-            .Where(t => t.Account is not null && options.SelectedAccounts.Contains(t.Account) && t.ValueDate >= fromDate && t.ValueDate <= toDate)
+            .Where(t => t.Account is not null && options.SelectedAccounts.Contains(t.Account) && t.ValueDate >= fromDate && t.ValueDate <= toDate && options.TransactionMatchesLabelFilter(t))
             .GroupBy(c => c.Category);
 
         var firstBucketDate = GetDateBucketStart(fromDate, dateGrouping);

--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
@@ -9,13 +9,46 @@ public sealed class AnalyticsOptions
     public BigTableDateGrouping BigTableDateGrouping { get; set; } = BigTableDateGrouping.Month;
     public ISet<Account> SelectedAccounts { get; } = new HashSet<Account>();
 
+    public ISet<string> SelectedLabels { get; } = new HashSet<string>(StringComparer.Ordinal);
+
     public ISet<int> BigTableDisabledCategories { get; } = new HashSet<int>();
     public ISet<string> BigTableDisabledCategoryGroups { get; } = new HashSet<string>(StringComparer.Ordinal);
     public ISet<string> BigTableCollapsedCategoryGroups { get; } = new HashSet<string>(StringComparer.Ordinal);
 
+    public bool IsLabelFilterActive => SelectedLabels.Count > 0;
+
+    public bool IsLabelEnabled(string label) => SelectedLabels.Count == 0 || SelectedLabels.Contains(label);
+
+    public bool TransactionMatchesLabelFilter(Transaction transaction)
+    {
+        if (SelectedLabels.Count == 0)
+            return true;
+
+        if (transaction.Labels is null || transaction.Labels.Length == 0)
+            return false;
+
+        return transaction.Labels.Any(l => SelectedLabels.Contains(l));
+    }
+
     public bool IsGroupEnabled(string? name) => !BigTableDisabledCategoryGroups.Contains(name ?? "");
     public bool IsCategoryEnabled(int categoryId) => !BigTableDisabledCategories.Contains(categoryId);
     public bool IsGroupCollapsed(string? name) => BigTableCollapsedCategoryGroups.Contains(name ?? "");
+
+    public void ToggleLabel(string label)
+    {
+        if (!SelectedLabels.Remove(label))
+        {
+            _ = SelectedLabels.Add(label);
+        }
+
+        OptionChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public void SelectAllLabels()
+    {
+        SelectedLabels.Clear();
+        OptionChanged?.Invoke(this, EventArgs.Empty);
+    }
 
     public void ToggleDisabledCategory(int categoryId)
     {

--- a/src/Meziantou.Moneiz.Core/Database.Label.cs
+++ b/src/Meziantou.Moneiz.Core/Database.Label.cs
@@ -1,0 +1,58 @@
+namespace Meziantou.Moneiz.Core;
+
+public partial class Database
+{
+    public IEnumerable<string> GetAllLabels()
+    {
+        return Transactions
+            .Where(t => t.Labels is { Length: > 0 })
+            .SelectMany(t => t.Labels!)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.CurrentCultureIgnoreCase);
+    }
+
+    public void RenameLabel(string oldName, string newName)
+    {
+        if (string.IsNullOrWhiteSpace(newName))
+            throw new ArgumentException("Label name cannot be empty.", nameof(newName));
+
+        using (DeferEvents())
+        {
+            foreach (var transaction in Transactions.ToList())
+            {
+                if (transaction.Labels is null)
+                    continue;
+
+                var index = Array.IndexOf(transaction.Labels, oldName);
+                if (index < 0)
+                    continue;
+
+                var newLabels = (string[])transaction.Labels.Clone();
+                newLabels[index] = newName;
+
+                // Deduplicate in case newName was already present
+                transaction.Labels = newLabels.Distinct(StringComparer.Ordinal).ToArray();
+                SaveTransaction(transaction);
+            }
+        }
+    }
+
+    public void DeleteLabel(string name)
+    {
+        using (DeferEvents())
+        {
+            foreach (var transaction in Transactions.ToList())
+            {
+                if (transaction.Labels is null)
+                    continue;
+
+                if (!transaction.Labels.Contains(name))
+                    continue;
+
+                var newLabels = transaction.Labels.Where(l => !string.Equals(l, name, StringComparison.Ordinal)).ToArray();
+                transaction.Labels = newLabels.Length > 0 ? newLabels : null;
+                SaveTransaction(transaction);
+            }
+        }
+    }
+}

--- a/src/Meziantou.Moneiz.Core/Transaction.cs
+++ b/src/Meziantou.Moneiz.Core/Transaction.cs
@@ -101,6 +101,9 @@ public sealed class Transaction
         set => _linkedTransactionId = value;
     }
 
+    [JsonPropertyName("k")]
+    public string[]? Labels { get; set; }
+
     [JsonIgnore]
     public string? FinalTitle => Payee?.ToString() ?? LinkedTransaction?.Account?.ToString();
 

--- a/src/Meziantou.Moneiz.Core/TransactionEdit.cs
+++ b/src/Meziantou.Moneiz.Core/TransactionEdit.cs
@@ -16,6 +16,7 @@ public sealed class TransactionEdit
     public DateOnly ValueDate { get; set; }
     public decimal Amount { get; set; }
     public string? Comment { get; set; }
+    public string[]? Labels { get; set; }
 
     public static TransactionEdit FromTransaction(Transaction transaction, bool createNewTransaction = false, bool editCurrentTransaction = false)
     {
@@ -30,6 +31,7 @@ public sealed class TransactionEdit
             Comment = transaction.Comment,
             Payee = transaction.Payee?.Name,
             ValueDate = transaction.ValueDate,
+            Labels = transaction.Labels,
             _editCurrentTransaction = editCurrentTransaction,
         };
     }
@@ -73,6 +75,7 @@ public sealed class TransactionEdit
             transaction.ValueDate = ValueDate;
             transaction.Amount = !_editCurrentTransaction && InterAccount ? -Math.Abs(Amount) : Amount;
             transaction.Comment = Comment;
+            transaction.Labels = Labels is { Length: > 0 } ? Labels : null;
 
             if (InterAccount)
             {
@@ -94,6 +97,7 @@ public sealed class TransactionEdit
                 creditedTransaction.ValueDate = transaction.ValueDate;
                 creditedTransaction.Amount = -transaction.Amount;
                 creditedTransaction.Comment = Comment;
+                creditedTransaction.Labels = transaction.Labels;
 
                 creditedTransaction.LinkedTransaction = transaction;
                 transaction.LinkedTransaction = creditedTransaction;

--- a/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
@@ -51,8 +51,23 @@
 			</ul>
 		</div>
 
-		<h2>Period</h2>
-		<div class="form-group">
+		@if (allLabels!.Any())
+		{
+			<h2>Labels</h2>
+			<div class="form-group">
+				<div class="chip-group">
+					<span class="chip-label">Filter:</span>
+					<span class="chip @(!options.IsLabelFilterActive ? "selected" : "")" @onclick="() => SelectAllLabels()">All</span>
+					@foreach (var label in allLabels!)
+					{
+						var capturedLabel = label;
+						<span class="chip @(options.SelectedLabels.Contains(capturedLabel) ? "selected" : "")" @onclick="() => options.ToggleLabel(capturedLabel)">@capturedLabel</span>
+					}
+				</div>
+			</div>
+		}
+
+		<h2>Period</h2>		<div class="form-group">
 			<div class="chip-group">
 				<span class="chip @(IsPeriodSelected("month") ? "selected" : "")" @onclick="() => SelectCurrentMonth()">This month</span>
 				<span class="chip @(IsPeriodSelected("year") ? "selected" : "")" @onclick="() => SelectCurrentYear()">This year</span>
@@ -94,6 +109,7 @@
 @code {
 	Database? database;
 	IList<Account>? allAccounts;
+	IList<string>? allLabels;
 	AnalyticsOptions options = new();
 
 	bool showDetails;
@@ -103,6 +119,7 @@
 	{
 		database = await DatabaseProvider.GetDatabase();
 		allAccounts = database.VisibleAccounts.Concat(database.ClosedAccounts).ToList();
+		allLabels = database.GetAllLabels().ToList();
 		options.SelectedAccounts.AddRange(allAccounts.Where(account => !account.Closed));
 
 		options.OptionChanged += OnOptionsChanged;
@@ -112,6 +129,11 @@
 	{
 		Generate();
 		InvokeAsync(StateHasChanged);
+	}
+
+	private void SelectAllLabels()
+	{
+		options.SelectAllLabels();
 	}
 
 	private void SelectAll()

--- a/src/Meziantou.Moneiz/Pages/Labels/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Labels/Index.razor
@@ -1,0 +1,155 @@
+@page "/labels"
+@inject DatabaseProvider DatabaseProvider
+
+<h1>My labels</h1>
+
+<LoadingIndicator IsLoading="database == null">
+    @if (!_labels.Any())
+    {
+        <p>No labels found. Add labels to your transactions to see them here.</p>
+    }
+    else
+    {
+        <table>
+            <thead>
+                <tr>
+                    <th>Label</th>
+                    <th style="text-align: right"># Transactions</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in _labels)
+                {
+                    var capturedItem = item;
+                    <tr>
+                        <td>
+                            @if (_renameTarget == capturedItem.Label)
+                            {
+                                <input type="text"
+                                       value="@_renameValue"
+                                       @oninput="e => _renameValue = e.Value?.ToString() ?? string.Empty"
+                                       @onkeydown="e => OnRenameKeyDown(e, capturedItem.Label)"
+                                       @ref="_renameInput" />
+                                <button type="button" class="btn-link" @onclick="() => CommitRename(capturedItem.Label)">Save</button>
+                                <button type="button" class="btn-link" @onclick="CancelRename">Cancel</button>
+                                @if (_renameError is not null)
+                                {
+                                    <span class="validation-message">@_renameError</span>
+                                }
+                            }
+                            else
+                            {
+                                @capturedItem.Label
+                            }
+                        </td>
+                        <td style="text-align: right">
+                            <a href="/labels/@(Uri.EscapeDataString(capturedItem.Label))/transactions">@capturedItem.TransactionCount</a>
+                        </td>
+                        <td class="commands">
+                            <Dropdown>
+                                <li><a class="view-transactions" href="/labels/@(Uri.EscapeDataString(capturedItem.Label))/transactions"><i class="fas fa-search"></i> View transactions</a></li>
+                                <li><button type="button" class="btn-link" @onclick="() => BeginRename(capturedItem.Label)"><i class="fas fa-pencil-alt"></i> Rename</button></li>
+                                <li><button type="button" class="btn-link" @onclick="() => Delete(capturedItem.Label)"><i class="fas fa-trash" style="color: red"></i> Delete</button></li>
+                            </Dropdown>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    }
+</LoadingIndicator>
+
+@code {
+    Database? database;
+    List<LabelWithCount> _labels = [];
+    string? _renameTarget;
+    string _renameValue = string.Empty;
+    string? _renameError;
+    ElementReference _renameInput;
+
+    protected override async Task OnInitializedAsync()
+    {
+        database = await DatabaseProvider.GetDatabase();
+        LoadLabels();
+    }
+
+    private void LoadLabels()
+    {
+        if (database is null)
+            return;
+
+        var countByLabel = database.Transactions
+            .Where(t => t.Labels is { Length: > 0 })
+            .SelectMany(t => t.Labels!)
+            .GroupBy(l => l, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.Count());
+
+        _labels = database.GetAllLabels()
+            .Select(l => new LabelWithCount(l, countByLabel.GetValueOrDefault(l, 0)))
+            .ToList();
+    }
+
+    private void BeginRename(string label)
+    {
+        _renameTarget = label;
+        _renameValue = label;
+        _renameError = null;
+    }
+
+    private void CancelRename()
+    {
+        _renameTarget = null;
+        _renameError = null;
+    }
+
+    private async Task CommitRename(string oldName)
+    {
+        Debug.Assert(database is not null);
+
+        var newName = _renameValue.Trim();
+        if (string.IsNullOrEmpty(newName))
+        {
+            _renameError = "Label name cannot be empty.";
+            return;
+        }
+
+        if (string.Equals(newName, oldName, StringComparison.Ordinal))
+        {
+            CancelRename();
+            return;
+        }
+
+        database.RenameLabel(oldName, newName);
+        await DatabaseProvider.Save();
+        _renameTarget = null;
+        _renameError = null;
+        LoadLabels();
+    }
+
+    private async Task OnRenameKeyDown(KeyboardEventArgs e, string oldName)
+    {
+        if (e.Key == "Enter")
+        {
+            await CommitRename(oldName);
+        }
+        else if (e.Key == "Escape")
+        {
+            CancelRename();
+        }
+    }
+
+    private async Task Delete(string label)
+    {
+        Debug.Assert(database is not null);
+
+        if (GlobalInterop.Confirm($"Do you really want to delete the label '{label}' from all transactions?"))
+        {
+            database.DeleteLabel(label);
+            await DatabaseProvider.Save();
+            LoadLabels();
+        }
+    }
+
+    private sealed record LabelWithCount(string Label, int TransactionCount);
+}

--- a/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
+++ b/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
@@ -40,6 +40,13 @@
         </label>
     </div>
 
+    <div class="form-group">
+        <label>
+            <InputCheckbox @bind-Value="displaySettings.ShowLabels" />
+            Show labels column
+        </label>
+    </div>
+
     <button type="submit">Save</button>
 </EditForm>
 

--- a/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
@@ -121,6 +121,13 @@
 			</label>
 		</div>
 
+		<div class="form-group">
+			<label>
+				Labels
+			</label>
+			<InputLabels @bind-Value="model.Labels" />
+		</div>
+
 		<button type="submit">Submit</button>
 	</EditForm>
 </LoadingIndicator>

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -118,8 +118,10 @@ else
                         Comment @GetSortIndicator(SortColumn.Comment)
                     </a>
                 </th>
-                <th>Labels</th>
-                <th></th>
+                @if (displaySettings.ShowLabels)
+                {
+                    <th>Labels</th>
+                }
             </tr>
         </thead>
 
@@ -211,18 +213,21 @@ else
                             @transaction.Comment
                         }
                     </td>
-                    <td id="@GetInlineEditorCellId(transaction, EditColumn.Labels)"
-                        class="@GetInlineEditCellClass(transaction, EditColumn.Labels)"
-                        @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Labels)">
-                        @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Labels)
-                        {
-                            @FormatLabels(transaction.Labels)
-                        }
-                        else
-                        {
-                            @FormatLabels(transaction.Labels)
-                        }
-                    </td>
+                    @if (displaySettings.ShowLabels)
+                    {
+                        <td id="@GetInlineEditorCellId(transaction, EditColumn.Labels)"
+                            class="@GetInlineEditCellClass(transaction, EditColumn.Labels)"
+                            @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Labels)">
+                            @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Labels)
+                            {
+                                @FormatLabels(transaction.Labels)
+                            }
+                            else
+                            {
+                                @FormatLabels(transaction.Labels)
+                            }
+                        </td>
+                    }
                     <td class="commands">
                         <Dropdown>
                             <li><button type="button" class="btn-link duplicate" @onclick="() => QuickDuplicate(transaction)"><i class="fas fa-copy"></i> Quick duplicate</button></li>

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -3,6 +3,7 @@
 @page "/categories/{CategoryId:int}/transactions"
 @page "/category-group/{CategoryGroup}/transactions"
 @page "/payees/{PayeeId:int}/transactions"
+@page "/labels/{Label}/transactions"
 @using System.Globalization
 @using System.Diagnostics.CodeAnalysis
 @using System.Diagnostics
@@ -117,6 +118,7 @@ else
                         Comment @GetSortIndicator(SortColumn.Comment)
                     </a>
                 </th>
+                <th>Labels</th>
                 <th></th>
             </tr>
         </thead>
@@ -209,6 +211,18 @@ else
                             @transaction.Comment
                         }
                     </td>
+                    <td id="@GetInlineEditorCellId(transaction, EditColumn.Labels)"
+                        class="@GetInlineEditCellClass(transaction, EditColumn.Labels)"
+                        @ondblclick="() => BeginInlineEdit(transaction, EditColumn.Labels)">
+                        @if (currentEdit?.Id == transaction.Id && editColumn == EditColumn.Labels)
+                        {
+                            @FormatLabels(transaction.Labels)
+                        }
+                        else
+                        {
+                            @FormatLabels(transaction.Labels)
+                        }
+                    </td>
                     <td class="commands">
                         <Dropdown>
                             <li><button type="button" class="btn-link duplicate" @onclick="() => QuickDuplicate(transaction)"><i class="fas fa-copy"></i> Quick duplicate</button></li>
@@ -228,6 +242,14 @@ else
                                 if (transaction.Category.GroupName != null)
                                 {
                                     <li><a class="view-transactions" href="/category-group/@(Uri.EscapeDataString(transaction.Category.GroupName))/transactions"><i class="fas fa-search"></i> View Transactions with category group '@transaction.Category.GroupName'</a></li>
+                                }
+                            }
+
+                            @if (transaction.Labels is { Length: > 0 })
+                            {
+                                foreach (var txLabel in transaction.Labels)
+                                {
+                                    <li><a class="view-transactions" href="/labels/@(Uri.EscapeDataString(txLabel))/transactions"><i class="fas fa-tag"></i> View Transactions with label '@txLabel'</a></li>
                                 }
                             }
 
@@ -282,6 +304,13 @@ else
                        @onkeydown="e => InlineEditorKeyDown(e)"
                        @onblur="e => EndInlineEdit()" />
             }
+            else if (editColumn == EditColumn.Labels)
+            {
+                <EditForm Model="currentEdit" Context="editContext">
+                    <InputLabels @bind-Value="currentEdit.Labels" />
+                    <button type="button" class="btn-link" @onclick="EndInlineEdit">Done</button>
+                </EditForm>
+            }
         </div>
     }
 }
@@ -311,6 +340,9 @@ else
 
     [Parameter]
     public int? PayeeId { get; set; }
+
+    [Parameter]
+    public string? Label { get; set; }
 
     [Parameter, SupplyParameterFromQuery(Name = "search")]
     public string? Search { get; set; }
@@ -347,6 +379,7 @@ else
             CategoryId is null &&
             CategoryGroup is null &&
             PayeeId is null &&
+            Label is null &&
             !HasSearch &&
             sortColumn is SortColumn.OperationDate &&
             !sortAscending;
@@ -475,6 +508,11 @@ else
         if (!string.IsNullOrEmpty(CategoryGroup))
         {
             result = result.Where(t => string.Equals(t.Category?.GroupName, CategoryGroup, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrEmpty(Label))
+        {
+            result = result.Where(t => t.Labels is not null && t.Labels.Contains(Label, StringComparer.Ordinal));
         }
 
         if (HasSearch)
@@ -630,7 +668,7 @@ else
         currentEdit = TransactionEdit.FromTransaction(transaction, editCurrentTransaction: true);
         editColumn = column;
         inlineEditorStyle = null;
-        focusInlineEditorRequested = column != EditColumn.Category;
+        focusInlineEditorRequested = column != EditColumn.Category && column != EditColumn.Labels;
 
         var rect = await JSRuntime.InvokeAsync<BoundingClientRect>("MoneizGetElementDocumentRectById", GetInlineEditorCellId(transaction, column));
         inlineEditorStyle = FormattableString.Invariant($"top: {rect.Top}px; left: {rect.Left}px; min-width: {rect.Width}px;");
@@ -650,7 +688,7 @@ else
             inlineEditorStyle = null;
             focusInlineEditorRequested = false;
         }
-        else if (e.Key == "Enter" && editColumn != EditColumn.Category)
+        else if (e.Key == "Enter" && editColumn != EditColumn.Category && editColumn != EditColumn.Labels)
         {
             await EndInlineEdit();
         }
@@ -681,12 +719,16 @@ else
     private string? FormatCategory(Category? category)
         => displaySettings.FormatCategory(category);
 
+    private static string? FormatLabels(string[]? labels)
+        => labels is { Length: > 0 } ? string.Join(", ", labels) : null;
+
     private enum EditColumn
     {
         Amount,
         Comment,
         Date,
         Category,
+        Labels,
     }
 
     private enum SortColumn

--- a/src/Meziantou.Moneiz/Pages/Transactions/TransactionQuery.cs
+++ b/src/Meziantou.Moneiz/Pages/Transactions/TransactionQuery.cs
@@ -30,6 +30,7 @@ internal static class TransactionQueries
         builder.AddHandler("category", (transaction, text) => MatchStringValue(transaction.Category?.Name, text));
         builder.AddHandler("categoryGroup", (transaction, text) => MatchStringValue(transaction.Category?.GroupName, text));
         builder.AddHandler("comment", (transaction, text) => MatchStringValue(transaction.Comment, text));
+        builder.AddHandler("label", (transaction, text) => transaction.Labels is not null && transaction.Labels.Any(l => MatchStringValue(l, text)));
         builder.AddHandler<TransactionState>("state", (transaction, value) => transaction.State == value);
         builder.AddRangeHandler<DateOnly>("date", (transaction, range) => range.IsInRange(transaction.ValueDate));
         builder.AddRangeHandler<decimal>("amount", (transaction, range) => range.IsInRange(transaction.Amount));
@@ -51,6 +52,15 @@ internal static class TransactionQueries
 
             if (MatchStringValue(transaction.Comment, text))
                 return true;
+
+            if (transaction.Labels is not null)
+            {
+                foreach (var label in transaction.Labels)
+                {
+                    if (MatchStringValue(label, text))
+                        return true;
+                }
+            }
 
             if (amount.HasValue)
             {

--- a/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
+++ b/src/Meziantou.Moneiz/Services/MoneizDisplaySettings.cs
@@ -18,6 +18,7 @@ public class MoneizDisplaySettings
     public bool SidebarCollapsed { get; set; }
     public int? SidebarMaxWidth { get; set; } = 400;
     public CategoryDisplayMode CategoryDisplayMode { get; set; } = CategoryDisplayMode.Name;
+    public bool ShowLabels { get; set; } = true;
 
     public string FormatDate(DateOnly date) => DateFormat is null ? date.ToShortDateString() : date.ToString(DateFormat, CultureInfo.InvariantCulture);
     public string? FormatDate(DateOnly? date) => DateFormat is null ? date?.ToShortDateString() : date?.ToString(DateFormat, CultureInfo.InvariantCulture);

--- a/src/Meziantou.Moneiz/Shared/InputLabels.razor
+++ b/src/Meziantou.Moneiz/Shared/InputLabels.razor
@@ -1,0 +1,128 @@
+@inject DatabaseProvider DatabaseProvider
+
+<div class="input-labels">
+    <div class="input-labels-chips">
+        @foreach (var label in _currentLabels)
+        {
+            var capturedLabel = label;
+            <span class="chip selected input-labels-chip">
+                @capturedLabel
+                <button type="button" class="input-labels-remove" @onclick="() => RemoveLabel(capturedLabel)" aria-label="Remove label @capturedLabel">×</button>
+            </span>
+        }
+    </div>
+    <div class="input-labels-input-row">
+        <input type="text"
+               class="input-labels-input"
+               placeholder="Add label…"
+               list="@_datalistId"
+               value="@_inputValue"
+               @oninput="OnInput"
+               @onkeydown="OnKeyDown"
+               @onchange="OnChange" />
+        <datalist id="@_datalistId">
+            @foreach (var suggestion in _suggestions)
+            {
+                <option value="@suggestion" />
+            }
+        </datalist>
+    </div>
+</div>
+
+@code {
+    private static int _idCounter;
+
+    private readonly string _datalistId = $"input-labels-datalist-{System.Threading.Interlocked.Increment(ref _idCounter)}";
+    private List<string> _currentLabels = [];
+    private List<string> _suggestions = [];
+    private string _inputValue = string.Empty;
+
+    [Parameter]
+    public string[]? Value { get; set; }
+
+    [Parameter]
+    public EventCallback<string[]?> ValueChanged { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var database = await DatabaseProvider.GetDatabase();
+        _suggestions = database.GetAllLabels().ToList();
+    }
+
+    protected override void OnParametersSet()
+    {
+        _currentLabels = Value is { Length: > 0 } ? [.. Value] : [];
+    }
+
+    private async Task AddLabel(string label)
+    {
+        label = label.Trim();
+        if (string.IsNullOrEmpty(label))
+            return;
+
+        // Support comma-separated labels
+        var parts = label.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        var changed = false;
+        foreach (var part in parts)
+        {
+            if (!string.IsNullOrEmpty(part) && !_currentLabels.Contains(part, StringComparer.Ordinal))
+            {
+                _currentLabels.Add(part);
+                if (!_suggestions.Contains(part, StringComparer.Ordinal))
+                {
+                    _suggestions.Add(part);
+                    _suggestions.Sort(StringComparer.CurrentCultureIgnoreCase);
+                }
+
+                changed = true;
+            }
+        }
+
+        _inputValue = string.Empty;
+
+        if (changed)
+        {
+            await RaiseValueChanged();
+        }
+    }
+
+    private async Task RemoveLabel(string label)
+    {
+        if (_currentLabels.Remove(label))
+        {
+            await RaiseValueChanged();
+        }
+    }
+
+    private async Task OnKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or "," or "Tab")
+        {
+            await AddLabel(_inputValue);
+        }
+        else if (e.Key == "Backspace" && string.IsNullOrEmpty(_inputValue) && _currentLabels.Count > 0)
+        {
+            _currentLabels.RemoveAt(_currentLabels.Count - 1);
+            await RaiseValueChanged();
+        }
+    }
+
+    private void OnInput(ChangeEventArgs e)
+    {
+        _inputValue = e.Value?.ToString() ?? string.Empty;
+    }
+
+    private async Task OnChange(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString() ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            await AddLabel(value);
+        }
+    }
+
+    private async Task RaiseValueChanged()
+    {
+        await ValueChanged.InvokeAsync(_currentLabels.Count > 0 ? [.. _currentLabels] : null);
+    }
+}

--- a/src/Meziantou.Moneiz/Shared/NavMenu.razor
+++ b/src/Meziantou.Moneiz/Shared/NavMenu.razor
@@ -24,6 +24,7 @@
             <li><NavLink href="/transactions"><i class="fas fa-list"></i><span>All transactions</span></NavLink></li>
             <li><NavLink href="/accounts"><i class="fas fa-university"></i><span>My accounts</span></NavLink></li>
             <li><NavLink href="/categories"><i class="fas fa-tags"></i><span>My categories</span></NavLink></li>
+            <li><NavLink href="/labels"><i class="fas fa-tag"></i><span>My labels</span></NavLink></li>
             <li><NavLink href="/payees"><i class="fas fa-users"></i><span>My payees</span></NavLink></li>
             <li><NavLink href="/scheduler"><i class="fas fa-calendar"></i><span>My scheduler</span></NavLink></li>
             <li><NavLink href="/analytics"><i class="fas fa-chart-line"></i><span>Analytics</span></NavLink></li>

--- a/tests/Meziantou.Moneiz.CoreTests/AnalyticsModelTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/AnalyticsModelTests.cs
@@ -1,4 +1,5 @@
-﻿using Meziantou.Moneiz.Core;
+﻿using System.Globalization;
+using Meziantou.Moneiz.Core;
 using Meziantou.Moneiz.Core.Analytics;
 
 namespace Meziantou.Moneiz.CoreTests;
@@ -91,7 +92,7 @@ public sealed class AnalyticsModelTests
             SelectedAccounts = { account },
         });
 
-        Assert.Equal(expectedDates, string.Join(",", result.BigTable!.Dates.Select(date => date.ToString("yyyy-MM-dd"))));
+        Assert.Equal(expectedDates, string.Join(",", result.BigTable!.Dates.Select(date => date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))));
         Assert.Equal(expectedTotals, string.Join(",", result.BigTable.Totals.Select(total => total.Total)));
     }
 }

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -13,7 +13,7 @@ public class DatabaseTests
         var category1 = new Category { Id = 1, Name = "c1", GroupName = "cg1" };
         var payee1 = new Payee { Id = 1, Name = "p1", DefaultCategory = category1 };
         var account1 = new Account { Id = 1, Name = "a1", CurrencyIsoCode = "USD" };
-        var transaction1 = new Transaction { Account = account1, Amount = 1, Category = category1, CheckedDate = today, Comment = "", Id = 1, Payee = payee1, ValueDate = today, };
+        var transaction1 = new Transaction { Account = account1, Amount = 1, Category = category1, CheckedDate = today, Comment = "", Id = 1, Payee = payee1, ValueDate = today, Labels = ["tag1", "tag2"] };
         var transaction2 = new Transaction { Account = account1, Amount = 1, Category = category1, CheckedDate = today, Comment = "", Id = 2, Payee = payee1, ValueDate = today, };
         var transaction3 = new Transaction { Account = account1, Amount = 1, Category = category1, CheckedDate = today, Comment = "", Id = 3, Payee = payee1, ValueDate = today, LinkedTransaction = transaction2 };
         transaction2.LinkedTransaction = transaction3;
@@ -48,6 +48,8 @@ public class DatabaseTests
         Assert.Same(imported.GetPayeeById(1), imported.GetTransactionById(1)!.Payee);
 
         Assert.Same(imported.GetTransactionById(2), imported.GetTransactionById(3)!.LinkedTransaction);
+        Assert.Equal((IEnumerable<string>)["tag1", "tag2"], imported.GetTransactionById(1)!.Labels);
+        Assert.Null(imported.GetTransactionById(2)!.Labels);
     }
 
     [Fact]
@@ -183,5 +185,83 @@ public class DatabaseTests
         };
         var date = JsonSerializer.Deserialize<DateOnly?>("\"2022-01-02T04:11:43.888Z\"", options);
         Assert.Equal(new DateOnly(2022, 01, 02), date);
+    }
+
+    [Fact]
+    public void RenameLabel_UpdatesAllMatchingTransactions()
+    {
+        var account = new Account { Id = 1 };
+        var t1 = new Transaction { Id = 1, Account = account, Amount = 1, ValueDate = Database.GetToday(), Labels = ["old", "other"] };
+        var t2 = new Transaction { Id = 2, Account = account, Amount = 2, ValueDate = Database.GetToday(), Labels = ["old"] };
+        var t3 = new Transaction { Id = 3, Account = account, Amount = 3, ValueDate = Database.GetToday(), Labels = ["unrelated"] };
+
+        var db = new Database
+        {
+            Accounts = { account },
+            Transactions = { t1, t2, t3 },
+        };
+
+        db.RenameLabel("old", "new");
+
+        Assert.Equal((IEnumerable<string>)["new", "other"], db.GetTransactionById(1)!.Labels);
+        Assert.Equal((IEnumerable<string>)["new"], db.GetTransactionById(2)!.Labels);
+        Assert.Equal((IEnumerable<string>)["unrelated"], db.GetTransactionById(3)!.Labels);
+    }
+
+    [Fact]
+    public void RenameLabel_DeduplicatesWhenNewNameAlreadyPresent()
+    {
+        var account = new Account { Id = 1 };
+        var t1 = new Transaction { Id = 1, Account = account, Amount = 1, ValueDate = Database.GetToday(), Labels = ["old", "new"] };
+
+        var db = new Database
+        {
+            Accounts = { account },
+            Transactions = { t1 },
+        };
+
+        db.RenameLabel("old", "new");
+
+        Assert.Equal((IEnumerable<string>)["new"], db.GetTransactionById(1)!.Labels);
+    }
+
+    [Fact]
+    public void DeleteLabel_RemovesLabelFromAllTransactions()
+    {
+        var account = new Account { Id = 1 };
+        var t1 = new Transaction { Id = 1, Account = account, Amount = 1, ValueDate = Database.GetToday(), Labels = ["remove", "keep"] };
+        var t2 = new Transaction { Id = 2, Account = account, Amount = 2, ValueDate = Database.GetToday(), Labels = ["remove"] };
+        var t3 = new Transaction { Id = 3, Account = account, Amount = 3, ValueDate = Database.GetToday(), Labels = ["keep"] };
+
+        var db = new Database
+        {
+            Accounts = { account },
+            Transactions = { t1, t2, t3 },
+        };
+
+        db.DeleteLabel("remove");
+
+        Assert.Equal((IEnumerable<string>)["keep"], db.GetTransactionById(1)!.Labels);
+        Assert.Null(db.GetTransactionById(2)!.Labels);
+        Assert.Equal((IEnumerable<string>)["keep"], db.GetTransactionById(3)!.Labels);
+    }
+
+    [Fact]
+    public void GetAllLabels_ReturnsDistinctSortedLabels()
+    {
+        var account = new Account { Id = 1 };
+        var t1 = new Transaction { Id = 1, Account = account, Amount = 1, ValueDate = Database.GetToday(), Labels = ["beta", "alpha"] };
+        var t2 = new Transaction { Id = 2, Account = account, Amount = 2, ValueDate = Database.GetToday(), Labels = ["beta", "gamma"] };
+        var t3 = new Transaction { Id = 3, Account = account, Amount = 3, ValueDate = Database.GetToday() };
+
+        var db = new Database
+        {
+            Accounts = { account },
+            Transactions = { t1, t2, t3 },
+        };
+
+        var labels = db.GetAllLabels().ToList();
+
+        Assert.Equal((IEnumerable<string>)["alpha", "beta", "gamma"], labels);
     }
 }


### PR DESCRIPTION
Users have no way to tag or categorize transactions beyond payee and category. This PR adds a free-form multi-label system to transactions, covering the full stack: data model, UI (list + edit + analytics), search, and CLI.

## What changed

**Core model**
- `Transaction.Labels` (`string[]?`, JSON key `"k"`) stores zero or more free-form string tags. Null when empty to keep serialized JSON compact and backwards-compatible.
- `TransactionEdit` copies and persists labels; `Save()` normalizes empty arrays to null and propagates to linked (transfer) transactions.
- `Database.Label.cs` adds `GetAllLabels()`, `RenameLabel()`, and `DeleteLabel()` helpers. Iteration uses `.ToList()` snapshots to avoid collection-modified exceptions when `SaveTransaction` triggers list updates.

**Shared component**
- New `InputLabels.razor` chip-style tag input: type a label and press Enter/comma/Tab to add, Backspace removes the last chip. Uses a `datalist` backed by all existing labels in the database for autocomplete.

**Transaction pages**
- Edit form gains a Labels field using `<InputLabels>`.
- Transaction list gains a Labels column with inline editing (chip editor in an overlay, committed with a "Done" button).
- New route `/labels/{Label}/transactions` filters the list to a single label.
- `TransactionQuery` supports a `label:` keyword and includes labels in the default text search.

**Labels management page**
- New page at `/labels` lists all labels in use across transactions, with inline rename and delete (with confirmation).
- Nav menu entry added after "My categories".

**Analytics**
- `AnalyticsOptions` gains `SelectedLabels`, `ToggleLabel`, and `TransactionMatchesLabelFilter`. Empty selection means "no filter" (show all); selecting labels shows only transactions that carry at least one of those labels.
- `BuildBigTable` and `BuildBalanceHistory` apply the label filter.
- Analytics page shows label chips to toggle individual labels, plus an "All" chip to reset.

**CLI**
- `add-transaction` and `update-transaction` accept `--labels` (comma-separated).
- `get-transactions` accepts `--label` for filtering; `Labels` is included in JSON output.