### PR TITLE
Add custom filter support to analytics

### DIFF
--- a/doc/search-query-language.md
+++ b/doc/search-query-language.md
@@ -2,7 +2,7 @@
 
 This page documents the search query language for each search box in the app.
 
-## Transactions search box
+## Transactions and analytics search boxes
 
 Applies to:
 
@@ -11,6 +11,7 @@ Applies to:
 - `/categories/{id}/transactions`
 - `/category-group/{group}/transactions`
 - `/payees/{id}/transactions`
+- `/analytics`
 
 ### Syntax
 
@@ -33,6 +34,7 @@ Applies to:
 | `category` | text | Category name |
 | `categoryGroup` | text | Category group name |
 | `comment` | text | Transaction comment |
+| `label` | text | Transaction label |
 | `state` | enum | `NotChecked`, `Checked`, `Reconciliated` |
 | `date` | date | Transaction date (`yyyy-MM-dd`) |
 | `amount` | number | Transaction amount |

--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsModel.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsModel.cs
@@ -37,7 +37,7 @@ public sealed class AnalyticsModel
             var initialBalance = database.GetBalance(account, fromDate.AddDays(-1));
             balances[0] = initialBalance;
             var transactions = database.Transactions
-                .Where(t => t.Account == account && t.ValueDate >= fromDate && t.ValueDate <= toDate && options.TransactionMatchesLabelFilter(t))
+                .Where(t => t.Account == account && t.ValueDate >= fromDate && t.ValueDate <= toDate && options.TransactionMatchesFilter(t))
                 .OrderBy(t => t.ValueDate);
             var currentIndex = 0;
             foreach (var transaction in transactions)
@@ -79,7 +79,7 @@ public sealed class AnalyticsModel
         var dateGrouping = options.BigTableDateGrouping;
 
         var transactionGroups = database.Transactions
-            .Where(t => t.Account is not null && options.SelectedAccounts.Contains(t.Account) && t.ValueDate >= fromDate && t.ValueDate <= toDate && options.TransactionMatchesLabelFilter(t))
+            .Where(t => t.Account is not null && options.SelectedAccounts.Contains(t.Account) && t.ValueDate >= fromDate && t.ValueDate <= toDate && options.TransactionMatchesFilter(t))
             .GroupBy(c => c.Category);
 
         var firstBucketDate = GetDateBucketStart(fromDate, dateGrouping);

--- a/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
+++ b/src/Meziantou.Moneiz.Core/Analytics/AnalyticsOptions.cs
@@ -10,6 +10,7 @@ public sealed class AnalyticsOptions
     public ISet<Account> SelectedAccounts { get; } = new HashSet<Account>();
 
     public ISet<string> SelectedLabels { get; } = new HashSet<string>(StringComparer.Ordinal);
+    public Predicate<Transaction>? TransactionFilter { get; set; }
 
     public ISet<int> BigTableDisabledCategories { get; } = new HashSet<int>();
     public ISet<string> BigTableDisabledCategoryGroups { get; } = new HashSet<string>(StringComparer.Ordinal);
@@ -28,6 +29,11 @@ public sealed class AnalyticsOptions
             return false;
 
         return transaction.Labels.Any(l => SelectedLabels.Contains(l));
+    }
+
+    public bool TransactionMatchesFilter(Transaction transaction)
+    {
+        return TransactionMatchesLabelFilter(transaction) && (TransactionFilter?.Invoke(transaction) ?? true);
     }
 
     public bool IsGroupEnabled(string? name) => !BigTableDisabledCategoryGroups.Contains(name ?? "");

--- a/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
@@ -1,5 +1,6 @@
 ﻿@page "/analytics"
 @using Meziantou.Moneiz.Core.Analytics
+@using Meziantou.Moneiz.Pages.Transactions
 @inject DatabaseProvider DatabaseProvider
 @implements IDisposable
 
@@ -67,6 +68,14 @@
 			</div>
 		}
 
+		<h2>Custom filter</h2>
+		<div class="input-group mb-3">
+			<input type="text" value="@customFilter" @oninput="OnCustomFilter" class="form-control" placeholder="🔍 Search">
+			<div class="input-group-append">
+				<a class="input-group-text" href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-query-language.md" target="_blank" title="Search query language help">?</a>
+			</div>
+		</div>
+
 		<h2>Period</h2>		<div class="form-group">
 			<div class="chip-group">
 				<span class="chip @(IsPeriodSelected("month") ? "selected" : "")" @onclick="() => SelectCurrentMonth()">This month</span>
@@ -111,6 +120,7 @@
 	IList<Account>? allAccounts;
 	IList<string>? allLabels;
 	AnalyticsOptions options = new();
+	string? customFilter;
 
 	bool showDetails;
 	AnalyticsModel? model;
@@ -246,7 +256,16 @@
 	private void Generate()
 	{
 		Debug.Assert(database is not null);
+		options.TransactionFilter = string.IsNullOrWhiteSpace(customFilter)
+			? null
+			: TransactionQueries.TransactionQuery.Build(customFilter).Evaluate;
 		model = AnalyticsModel.Build(database, options);
+	}
+
+	private void OnCustomFilter(ChangeEventArgs e)
+	{
+		customFilter = e.Value as string;
+		Generate();
 	}
 
 	private bool IsAllSelected()

--- a/tests/Meziantou.Moneiz.CoreTests/AnalyticsModelTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/AnalyticsModelTests.cs
@@ -95,4 +95,50 @@ public sealed class AnalyticsModelTests
         Assert.Equal(expectedDates, string.Join(",", result.BigTable!.Dates.Select(date => date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture))));
         Assert.Equal(expectedTotals, string.Join(",", result.BigTable.Totals.Select(total => total.Total)));
     }
+
+    [Fact]
+    public void ComputeModel_CustomFilter_IsCombinedWithLabelFilter()
+    {
+        var database = new Database();
+        var account = new Account();
+        database.Accounts.Add(account);
+
+        database.Transactions.Add(new Transaction
+        {
+            Account = account,
+            ValueDate = new DateOnly(2023, 1, 1),
+            Amount = 10m,
+            Labels = ["keep"],
+        });
+
+        database.Transactions.Add(new Transaction
+        {
+            Account = account,
+            ValueDate = new DateOnly(2023, 1, 2),
+            Amount = 6m,
+            Labels = ["drop-by-label"],
+        });
+
+        database.Transactions.Add(new Transaction
+        {
+            Account = account,
+            ValueDate = new DateOnly(2023, 1, 3),
+            Amount = -4m,
+            Labels = ["keep"],
+        });
+
+        var options = new AnalyticsOptions
+        {
+            FromDate = new DateOnly(2023, 1, 1),
+            ToDate = new DateOnly(2023, 1, 3),
+            TransactionFilter = static t => t.Amount > 0,
+            SelectedAccounts = { account },
+            SelectedLabels = { "keep" },
+        };
+
+        var result = AnalyticsModel.Build(database, options);
+
+        Assert.Equal(10m, result.BigTable!.Totals[^1].Total);
+        Assert.Equal(10m, result.BalanceHistory!.BalancesByAccount[0].Difference);
+    }
 }


### PR DESCRIPTION
## Why
Analytics already had account, label, and period filters, but it could not apply the same advanced transaction query syntax available on the transactions list. This adds that capability so users can build analytics on narrowed transaction subsets.

## What changed
- Added a `Custom filter` input on `/analytics` with the same query language help link used by the transactions page.
- Reused `TransactionQueries.TransactionQuery` to compile analytics filter expressions, keeping syntax and supported filters aligned with transaction list search.
- Extended `AnalyticsOptions` with a transaction predicate and applied it in `AnalyticsModel` for both balance history and big table calculations.
- Combined filtering with AND semantics across existing analytics options (accounts, date range, labels) and the new custom query filter.
- Updated `doc/search-query-language.md` to include analytics in scope and document the `label` field.
- Added a core test to verify custom filter + label filter composition.

## Validation
- `dotnet build src/Meziantou.Moneiz/Meziantou.Moneiz.csproj -nologo`
- `dotnet test tests/Meziantou.Moneiz.CoreTests/Meziantou.Moneiz.CoreTests.csproj --filter "FullyQualifiedName~AnalyticsModelTests" -nologo`