### PR TITLE
Fix inline amount editor losing decimal point and cursor position

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -294,10 +294,9 @@ else
             }
             else if (editColumn == EditColumn.Amount)
             {
-                <input type="number" @ref="inlineEditorInput"
-                       step="0.01"
-                       value="@currentEdit.Amount.ToString(CultureInfo.InvariantCulture)"
-                       @oninput="e => { if (decimal.TryParse((string?)e.Value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedAmount)) currentEdit.Amount = parsedAmount; }"
+                <input type="text" inputmode="decimal" @ref="inlineEditorInput"
+                       value="@inlineAmountRawValue"
+                       @oninput="e => inlineAmountRawValue = (string?)e.Value ?? string.Empty"
                        @onkeydown="e => InlineEditorKeyDown(e)"
                        @onblur="e => EndInlineEdit()" />
             }
@@ -333,6 +332,7 @@ else
     ElementReference inlineEditorInput;
     string? inlineEditorStyle;
     bool focusInlineEditorRequested;
+    string inlineAmountRawValue = "";
 
     [Parameter]
     public int? AccountId { get; set; }
@@ -675,6 +675,9 @@ else
         inlineEditorStyle = null;
         focusInlineEditorRequested = column != EditColumn.Category && column != EditColumn.Labels;
 
+        if (column == EditColumn.Amount)
+            inlineAmountRawValue = currentEdit.Amount.ToString(CultureInfo.InvariantCulture);
+
         var rect = await JSRuntime.InvokeAsync<BoundingClientRect>("MoneizGetElementDocumentRectById", GetInlineEditorCellId(transaction, column));
         inlineEditorStyle = FormattableString.Invariant($"top: {rect.Top}px; left: {rect.Left}px; min-width: {rect.Width}px;");
     }
@@ -704,6 +707,9 @@ else
 		Debug.Assert(database != null);
         if (currentEdit != null)
         {
+            if (editColumn == EditColumn.Amount && decimal.TryParse(inlineAmountRawValue, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedAmount))
+                currentEdit.Amount = parsedAmount;
+
             currentEdit.Save(database);
             await DatabaseProvider.Save();
             currentEdit = null;


### PR DESCRIPTION
Fixes #208

## Problem

When inline-editing a transaction amount like `120.16` and deleting the decimal digits `16`, the trailing decimal point disappeared and the cursor jumped to position 0.

**Root cause:** The inline amount `<input>` was `type="number"` with its `value` attribute bound directly to `currentEdit.Amount.ToString(...)`. On every keystroke, `@oninput` parsed the raw string and updated `currentEdit.Amount`, triggering a Blazor re-render that wrote the parsed decimal back to the input (e.g. `"120"` instead of `"120."`). This:
1. Stripped the trailing decimal point.
2. Updated the DOM `value` attribute, resetting the cursor to position 0.

With `type="number"` inputs, browsers also return `""` for intermediate invalid states like `"120."`, causing `TryParse` to fail and the field to snap back to the previous complete value.

## Fix

- Added a `string inlineAmountRawValue` field to hold the user's raw text while typing.
- Initialise it from `currentEdit.Amount` when beginning an inline edit.
- Changed the input to `type="text" inputmode="decimal"` so the browser never normalises intermediate values.
- `@oninput` now only updates `inlineAmountRawValue` (no immediate decimal parse). When Blazor re-renders, it binds `value="@inlineAmountRawValue"` — since the new value equals what the user just typed, the DOM diff is a no-op and the cursor is preserved.
- `EndInlineEdit` (called on blur or Enter) parses `inlineAmountRawValue` and updates `currentEdit.Amount` before saving; falls back to the existing value if parsing fails.