### PR TITLE
Preserve scheduled transaction progression on update

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
@@ -11,7 +11,7 @@ public partial class Database
         return ScheduledTransactions.FirstOrDefault(item => item.Id == id);
     }
 
-    public void SaveScheduledTransaction(ScheduledTransaction scheduledTransaction)
+    public void SaveScheduledTransaction(ScheduledTransaction scheduledTransaction, DateOnly? previousNextOccurenceDate = null)
     {
         using (DeferEvents())
         {
@@ -22,6 +22,11 @@ public partial class Database
             }
 
             AddOrReplace(ScheduledTransactions, existingTransaction, scheduledTransaction);
+
+            if (scheduledTransaction.NextOccurenceDate is null && previousNextOccurenceDate is not null)
+            {
+                scheduledTransaction.NextOccurenceDate = ComputeNextOccurenceDate(scheduledTransaction, previousNextOccurenceDate.Value);
+            }
 
             if (scheduledTransaction.NextOccurenceDate == null)
             {
@@ -73,7 +78,7 @@ public partial class Database
 
             if (scheduledTransaction.NextOccurenceDate == null)
             {
-                DateOnly? recurrenceDate = reccurenceRule.GetNextOccurrence(scheduledTransaction.StartDate.ToDateTime(TimeOnly.MinValue)) is DateTime nextDateTime ? DateOnly.FromDateTime(nextDateTime) : null;
+                DateOnly? recurrenceDate = ComputeNextOccurenceDate(scheduledTransaction, scheduledTransaction.StartDate);
                 scheduledTransaction.NextOccurenceDate = recurrenceDate;
                 if (scheduledTransaction.NextOccurenceDate == null)
                 {
@@ -136,5 +141,15 @@ public partial class Database
                 RaiseDatabaseChanged();
             }
         }
+    }
+
+    private static DateOnly? ComputeNextOccurenceDate(ScheduledTransaction scheduledTransaction, DateOnly startDate)
+    {
+        var recurrenceRule = scheduledTransaction.RecurrenceRule;
+        if (recurrenceRule is null)
+            return null;
+
+        var searchDate = startDate > scheduledTransaction.StartDate ? startDate : scheduledTransaction.StartDate;
+        return recurrenceRule.GetNextOccurrence(searchDate.ToDateTime(TimeOnly.MinValue)) is DateTime nextDateTime ? DateOnly.FromDateTime(nextDateTime) : null;
     }
 }

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -82,6 +82,7 @@ public partial class Edit
         Debug.Assert(_database is not null);
         Debug.Assert(_model is not null);
         var scheduledTransaction = _database.GetScheduledTransactionById(Id);
+        var previousNextOccurenceDate = scheduledTransaction?.NextOccurenceDate;
         scheduledTransaction ??= new ScheduledTransaction();
 
         // Reset the schedule if StartDate or RRule changed
@@ -115,7 +116,7 @@ public partial class Edit
         scheduledTransaction.Category = _model.Category;
         scheduledTransaction.Amount = _model.Amount;
         scheduledTransaction.Comment = _model.Comment;
-        _database.SaveScheduledTransaction(scheduledTransaction);
+        _database.SaveScheduledTransaction(scheduledTransaction, previousNextOccurenceDate);
         await DatabaseProvider.Save();
         NavigationManager.NavigateToScheduler();
     }

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -76,6 +76,38 @@ public class DatabaseTests
     }
 
     [Fact]
+    public void UpdateScheduledTransaction_PreservesExistingProgression()
+    {
+        var db = new Database();
+        var account = new Account();
+        db.SaveAccount(account);
+
+        var scheduledTransaction = new ScheduledTransaction
+        {
+            Account = account,
+            Amount = 1,
+            RecurrenceRuleText = "FREQ=DAILY",
+            Name = "test",
+            StartDate = Database.GetToday().AddDays(-20),
+        };
+
+        db.SaveScheduledTransaction(scheduledTransaction);
+        var previousNextOccurenceDate = scheduledTransaction.NextOccurenceDate;
+        var transactionsCountBeforeUpdate = db.Transactions.Count;
+
+        Assert.NotNull(previousNextOccurenceDate);
+
+        scheduledTransaction.RecurrenceRuleText = "FREQ=WEEKLY";
+        scheduledTransaction.NextOccurenceDate = null;
+
+        db.SaveScheduledTransaction(scheduledTransaction, previousNextOccurenceDate);
+
+        Assert.Equal(transactionsCountBeforeUpdate, db.Transactions.Count);
+        Assert.NotNull(scheduledTransaction.NextOccurenceDate);
+        Assert.True(scheduledTransaction.NextOccurenceDate >= previousNextOccurenceDate);
+    }
+
+    [Fact]
     public void GetPayeeSuggestionsMatchesAndRanksNames()
     {
         var account = new Account { Id = 1 };


### PR DESCRIPTION
When editing a scheduled transaction, resetting `NextOccurenceDate` caused save-time processing to replay occurrences from `StartDate`, which could recreate historical transactions. This change keeps the schedule progression anchored to the existing next occurrence so updates continue forward instead of replaying history.

### What changed
- `Edit.razor.cs` now captures the previous `NextOccurenceDate` before applying recurrence/start-date edits and passes it to save.
- `Database.SaveScheduledTransaction` now accepts an optional previous-next-occurrence baseline and recomputes a new next occurrence from that baseline (bounded by `StartDate`) before deciding to regenerate transactions.
- Added a regression test: `UpdateScheduledTransaction_PreservesExistingProgression`.

### Notes
- New schedules and cases without a previous next occurrence still follow the existing processing path.
- This keeps behavior backward compatible while preventing unintended historical replay during updates.