### PR TITLE
Add labels support to scheduled transactions

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
@@ -93,6 +93,7 @@ public partial class Database
                     Category = scheduledTransaction.Category,
                     Comment = scheduledTransaction.Comment,
                     Amount = interAccount ? -Math.Abs(scheduledTransaction.Amount) : scheduledTransaction.Amount,
+                    Labels = scheduledTransaction.Labels,
                     Payee = scheduledTransaction.Payee,
                     ValueDate = transactionDate,
                 };
@@ -107,6 +108,7 @@ public partial class Database
                         Category = scheduledTransaction.Category,
                         Comment = scheduledTransaction.Comment,
                         Amount = Math.Abs(scheduledTransaction.Amount),
+                        Labels = scheduledTransaction.Labels,
                         Payee = scheduledTransaction.Payee,
                         ValueDate = transactionDate,
                         LinkedTransaction = transaction,

--- a/src/Meziantou.Moneiz.Core/ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/ScheduledTransaction.cs
@@ -105,6 +105,9 @@ public sealed class ScheduledTransaction
     [JsonConverter(typeof(NullableDateOnlyJsonConverter))]
     public DateOnly? NextOccurenceDate { get; set; }
 
+    [JsonPropertyName("l")]
+    public string[]? Labels { get; set; }
+
     [JsonIgnore]
     public RecurrenceRule? RecurrenceRule
     {

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
@@ -103,6 +103,13 @@
             </label>
         </div>
 
+        <div class="form-group">
+            <label>
+                Labels
+            </label>
+            <InputLabels @bind-Value="_model.Labels" />
+        </div>
+
         <button type="submit">Submit</button>
     </EditForm>
 </LoadingIndicator>

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -47,6 +47,7 @@ public partial class Edit
                 Amount = scheduledTransaction.Amount,
                 Category = scheduledTransaction.Category,
                 Comment = scheduledTransaction.Comment,
+                Labels = scheduledTransaction.Labels,
                 Payee = scheduledTransaction.Payee?.Name,
                 Name = scheduledTransaction.Name,
                 RecurrenceRule = scheduledTransaction.RecurrenceRuleText,
@@ -70,6 +71,7 @@ public partial class Edit
                     _model.Payee = transaction.Payee?.Name;
                     _model.Category = transaction.Category;
                     _model.Amount = transaction.Amount;
+                    _model.Labels = transaction.Labels;
                     _model.StartDate = transaction.ValueDate.AddDays(1);
                     _model.RecurrenceRule = $"FREQ=MONTHLY;BYMONTHDAY={transaction.ValueDate.Day.ToStringInvariant()};INTERVAL=1";
                 }
@@ -115,6 +117,7 @@ public partial class Edit
         scheduledTransaction.Category = _model.Category;
         scheduledTransaction.Amount = _model.Amount;
         scheduledTransaction.Comment = _model.Comment;
+        scheduledTransaction.Labels = _model.Labels;
         _database.SaveScheduledTransaction(scheduledTransaction);
         await DatabaseProvider.Save();
         NavigationManager.NavigateToScheduler();
@@ -150,5 +153,6 @@ public partial class Edit
         public Category? Category { get; set; }
         public decimal Amount { get; set; }
         public string? Comment { get; set; }
+        public string[]? Labels { get; set; }
     }
 }

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -76,6 +76,28 @@ public class DatabaseTests
     }
 
     [Fact]
+    public void ScheduledTransaction_LabelsAreCopiedToGeneratedTransactions()
+    {
+        var db = new Database();
+        var account = new Account();
+        db.SaveAccount(account);
+
+        var scheduledTransaction = new ScheduledTransaction
+        {
+            Account = account,
+            Amount = 1,
+            RecurrenceRuleText = "FREQ=daily",
+            Name = "test",
+            StartDate = Database.GetToday(),
+            Labels = ["tag1", "tag2"],
+        };
+
+        db.SaveScheduledTransaction(scheduledTransaction);
+
+        Assert.All(db.Transactions, t => Assert.Equal((IEnumerable<string>)["tag1", "tag2"], t.Labels));
+    }
+
+    [Fact]
     public void GetPayeeSuggestionsMatchesAndRanksNames()
     {
         var account = new Account { Id = 1 };


### PR DESCRIPTION
Scheduled transactions had no way to attach labels, meaning any recurring transactions they generated would always be label-free. This PR adds full label support -- both in the edit form and in the transaction generation logic.

**What changed:**

- `ScheduledTransaction` gains a `Labels` property (JSON key `"l"`) so labels are persisted with the scheduled transaction
- `ProcessScheduledTransaction` now copies the labels to every generated transaction (both debit and credited sides for inter-account transfers)
- The edit form (`Pages/ScheduledTransactions/Edit.razor`) now includes an `InputLabels` field, consistent with the transaction edit form
- When duplicating a scheduled transaction or creating one from an existing transaction, labels are carried over
- A new test (`ScheduledTransaction_LabelsAreCopiedToGeneratedTransactions`) verifies the propagation logic