### PR TITLE
Preview next occurrences when editing scheduled transactions

### DIFF
--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
@@ -36,6 +36,19 @@
                 <option>FREQ=MONTHLY;BYMONTHDAY=1;INTERVAL=1</option>
                 <option>FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO,TU,WE,TH,FR;INTERVAL=1</option>
             </datalist>
+
+            @if (Id is not null && NextOccurrences.Count > 0)
+            {
+                <div>
+                    Next occurrences:
+                    <ul>
+                        @foreach (var occurrence in NextOccurrences)
+                        {
+                            <li><UserDate DateTime="@occurrence" /></li>
+                        }
+                    </ul>
+                </div>
+            }
         </div>
 
         @if (_database!.VisibleAccounts.Skip(1).Any())

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -4,12 +4,14 @@ using Meziantou.Moneiz.Core;
 using Meziantou.Moneiz.Extensions;
 using Meziantou.Moneiz.Services;
 using Meziantou.Framework;
+using Meziantou.Framework.Scheduling;
 using System.Diagnostics;
 
 namespace Meziantou.Moneiz.Pages.ScheduledTransactions;
 
 public partial class Edit
 {
+    private const int OccurrencePreviewCount = 5;
     private Database? _database;
     private EditModel? _model;
 
@@ -21,6 +23,21 @@ public partial class Edit
 
     [Parameter, SupplyParameterFromQuery]
     public int? CreateFromTransactionId { get; set; }
+
+    private IReadOnlyList<DateTime> NextOccurrences
+    {
+        get
+        {
+            if (_model is null)
+                return [];
+
+            var recurrenceRuleText = _model.RecurrenceRule.TrimAndNullify();
+            if (recurrenceRuleText is null || !RecurrenceRule.TryParse(recurrenceRuleText, out var recurrenceRule))
+                return [];
+
+            return recurrenceRule.GetNextOccurrences(_model.StartDate.ToDateTime(TimeOnly.MinValue)).Take(OccurrencePreviewCount).ToList();
+        }
+    }
 
     protected override async Task OnInitializedAsync()
     {


### PR DESCRIPTION
## Why
When editing a scheduled transaction, it is hard to validate whether the recurrence rule will generate the expected dates before saving.

## What changed
This adds a live preview in the scheduled transaction edit form that shows the next 5 occurrences computed from the current `StartDate` and `RecurrenceRule`.

The preview logic:
- Trims and validates the recurrence rule with `RecurrenceRule.TryParse`
- Uses `StartDate` as the reference date for `GetNextOccurrences(...)`
- Limits the result to 5 occurrences
- Renders the dates with the existing `UserDate` component

The preview is shown only when editing an existing scheduled transaction and when the rule is valid.