### PR TITLE
Use next occurrence as schedule edit start date

### DIFF
--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -68,7 +68,7 @@ public partial class Edit
                 Payee = scheduledTransaction.Payee?.Name,
                 Name = scheduledTransaction.Name,
                 RecurrenceRule = scheduledTransaction.RecurrenceRuleText,
-                StartDate = Id is null ? Database.GetToday() : scheduledTransaction.StartDate,
+                StartDate = Id is null ? Database.GetToday() : scheduledTransaction.NextOccurenceDate ?? scheduledTransaction.StartDate,
             };
         }
         else


### PR DESCRIPTION
When editing an existing scheduled transaction, the form currently reuses the original start date, which can cause the schedule reset flow to regenerate occurrences from the beginning. This change aligns edits with the current schedule state.

The edit model now initializes `StartDate` from `NextOccurenceDate` when available, and falls back to `StartDate` otherwise. This ensures that updating a schedule keeps the next generated transaction on the expected date instead of shifting back to historical occurrences.