### PR TITLE
Rename "Show label columns" to "Show labels" and apply setting everywhere

### DIFF
--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
@@ -116,7 +116,7 @@
             </label>
         </div>
 
-        @if (displaySettings.ShowLabels)
+        @if (_displaySettings.ShowLabels)
         {
             <div class="form-group">
                 <label>

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
@@ -116,12 +116,15 @@
             </label>
         </div>
 
-        <div class="form-group">
-            <label>
-                Labels
-            </label>
-            <InputLabels @bind-Value="_model.Labels" />
-        </div>
+        @if (displaySettings.ShowLabels)
+        {
+            <div class="form-group">
+                <label>
+                    Labels
+                </label>
+                <InputLabels @bind-Value="_model.Labels" />
+            </div>
+        }
 
         <button type="submit">Submit</button>
     </EditForm>

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -14,7 +14,7 @@ public partial class Edit
     private const int OccurrencePreviewCount = 5;
     private Database? _database;
     private EditModel? _model;
-    private MoneizDisplaySettings displaySettings = new();
+    private MoneizDisplaySettings _displaySettings = new();
 
     [Parameter]
     public int? Id { get; set; }
@@ -43,7 +43,7 @@ public partial class Edit
     protected override async Task OnInitializedAsync()
     {
         _database = await DatabaseProvider.GetDatabase();
-        displaySettings = await SettingsProvider.GetDisplaySettings();
+        _displaySettings = await SettingsProvider.GetDisplaySettings();
     }
 
     protected override void OnParametersSet()

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -14,6 +14,7 @@ public partial class Edit
     private const int OccurrencePreviewCount = 5;
     private Database? _database;
     private EditModel? _model;
+    private MoneizDisplaySettings displaySettings = new();
 
     [Parameter]
     public int? Id { get; set; }
@@ -42,6 +43,7 @@ public partial class Edit
     protected override async Task OnInitializedAsync()
     {
         _database = await DatabaseProvider.GetDatabase();
+        displaySettings = await SettingsProvider.GetDisplaySettings();
     }
 
     protected override void OnParametersSet()

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Index.razor
@@ -2,6 +2,7 @@
 @using Meziantou.Framework.Scheduling
 @inject DatabaseProvider DatabaseProvider
 @inject NavigationManager NavigationManager
+@inject IJSRuntime JSRuntime
 
 <h1>Scheduler</h1>
 
@@ -19,6 +20,10 @@
                     <th>Amount</th>
                     <th>Rule</th>
                     <th>Next occurrence</th>
+                    @if (displaySettings.ShowLabels)
+                    {
+                        <th>Labels</th>
+                    }
                     <th></th>
                 </tr>
             </thead>
@@ -43,6 +48,10 @@
                     </ul>
                 </details>
             </td>
+            @if (displaySettings.ShowLabels)
+            {
+                <td>@FormatLabels(scheduledTransaction.Labels)</td>
+            }
             <td class="commands">
                 <Dropdown>
                     <li><a class="duplicate" href="/scheduler/create?DuplicatedScheduleTransactionId=@scheduledTransaction.Id"><i class="fas fa-copy"></i> Duplicate</a></li>
@@ -56,10 +65,12 @@
 
 @code {
     Database? database;
+    MoneizDisplaySettings displaySettings = new();
 
     protected override async Task OnInitializedAsync()
     {
         database = await DatabaseProvider.GetDatabase();
+        displaySettings = await SettingsProvider.GetDisplaySettings();
     }
 
     private async Task Delete(ScheduledTransaction scheduledTransaction)
@@ -71,4 +82,7 @@
             await DatabaseProvider.Save();
         }
     }
+
+    private static string? FormatLabels(string[]? labels)
+        => labels is { Length: > 0 } ? string.Join(", ", labels) : null;
 }

--- a/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
+++ b/src/Meziantou.Moneiz/Pages/Settings/DisplaySettings.razor
@@ -43,7 +43,7 @@
     <div class="form-group">
         <label>
             <InputCheckbox @bind-Value="displaySettings.ShowLabels" />
-            Show labels column
+            Show labels
         </label>
     </div>
 

--- a/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
@@ -121,12 +121,15 @@
 			</label>
 		</div>
 
-		<div class="form-group">
-			<label>
-				Labels
-			</label>
-			<InputLabels @bind-Value="model.Labels" />
-		</div>
+		@if (displaySettings.ShowLabels)
+		{
+			<div class="form-group">
+				<label>
+					Labels
+				</label>
+				<InputLabels @bind-Value="model.Labels" />
+			</div>
+		}
 
 		<button type="submit">Submit</button>
 	</EditForm>
@@ -134,6 +137,7 @@
 
 @code {
 	Database? database;
+	MoneizDisplaySettings displaySettings = new();
 	TransactionEdit? model;
 	string? _quickCreateCategoryName;
 	string? _quickCreateCategoryGroupName;
@@ -146,6 +150,7 @@
 	protected override async Task OnInitializedAsync()
 	{
 		database = await DatabaseProvider.GetDatabase();
+		displaySettings = await SettingsProvider.GetDisplaySettings();
 	}
 
 	protected override void OnParametersSet()


### PR DESCRIPTION
The "Show labels" setting previously only controlled the labels column in the transaction list. This PR extends it to hide labels in all relevant UI surfaces when the option is disabled.

**Changes:**

- Renamed the setting label from "Show labels column" to "Show labels" in Display Settings
- Scheduled Transactions list: added a labels column that respects the setting
- Edit Transaction form: hides the labels field when the setting is off
- Edit Scheduled Transaction form: hides the labels field when the setting is off