### PR TITLE
Hide "My labels" sidebar link when Show labels is disabled

### DIFF
--- a/src/Meziantou.Moneiz/Shared/NavMenu.razor
+++ b/src/Meziantou.Moneiz/Shared/NavMenu.razor
@@ -24,7 +24,10 @@
             <li><NavLink href="/transactions"><i class="fas fa-list"></i><span>All transactions</span></NavLink></li>
             <li><NavLink href="/accounts"><i class="fas fa-university"></i><span>My accounts</span></NavLink></li>
             <li><NavLink href="/categories"><i class="fas fa-tags"></i><span>My categories</span></NavLink></li>
-            <li><NavLink href="/labels"><i class="fas fa-tag"></i><span>My labels</span></NavLink></li>
+            @if (displaySettings.ShowLabels)
+            {
+                <li><NavLink href="/labels"><i class="fas fa-tag"></i><span>My labels</span></NavLink></li>
+            }
             <li><NavLink href="/payees"><i class="fas fa-users"></i><span>My payees</span></NavLink></li>
             <li><NavLink href="/scheduler"><i class="fas fa-calendar"></i><span>My scheduler</span></NavLink></li>
             <li><NavLink href="/analytics"><i class="fas fa-chart-line"></i><span>Analytics</span></NavLink></li>
@@ -39,11 +42,13 @@
 
 @code {
     Database? database;
+    MoneizDisplaySettings displaySettings = new();
 
     protected override async Task OnInitializedAsync()
     {
         DatabaseProvider.DatabaseChanged += OnDatabaseChanged;
         await LoadDatabase();
+        displaySettings = await SettingsProvider.GetDisplaySettings();
     }
 
     public void Dispose()


### PR DESCRIPTION
When the "Show labels" display setting is turned off, the labels column and input are already hidden throughout the app. However, the "My labels" nav link remained visible in the sidebar, which was inconsistent.

This change loads `displaySettings` in `NavMenu.razor` and wraps the labels nav item in an `@if (displaySettings.ShowLabels)` check, so the link is hidden when labels are disabled.