### PR TITLE
Show next occurrences when creating a scheduled transaction

### DIFF
--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
@@ -37,7 +37,7 @@
                 <option>FREQ=MONTHLY;BYSETPOS=-1;BYDAY=MO,TU,WE,TH,FR;INTERVAL=1</option>
             </datalist>
 
-            @if (Id is not null && NextOccurrences.Count > 0)
+            @if (NextOccurrences.Count > 0)
             {
                 <div>
                     Next occurrences:


### PR DESCRIPTION
When editing a scheduled transaction, the form already shows a preview of the next occurrences based on the start date and recurrence rule. This preview was hidden on the create form due to an `Id is not null` guard, even though the underlying `NextOccurrences` property works purely from the model and doesn't depend on an existing record.

Removing that condition makes the preview visible during creation too, giving users immediate feedback on their recurrence rule before saving.