### PR TITLE
Style sortable table header links as plain text

### DIFF
--- a/src/Meziantou.Moneiz/wwwroot/css/_table.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_table.css
@@ -15,6 +15,12 @@ thead th {
   border-top: 0;
 }
 
+thead th a {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
 th, td {
   padding: 8px;
   text-align: left;


### PR DESCRIPTION
Sortable table headers render as `<a>` tags, which browsers style as blue underlined links by default. This is visually inconsistent with the rest of the table headers.

Add a `thead th a` rule in `_table.css` that removes the link color and underline (`color: inherit`, `text-decoration: none`) while preserving the pointer cursor so users can still tell the header is clickable.