### PR TITLE
Fix EditForm crash when creating or editing a scheduled transaction

### DIFF
--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor
@@ -5,7 +5,7 @@
 
 <h1>Create scheduled transaction</h1>
 
-<LoadingIndicator IsLoading="_database is null">
+<LoadingIndicator IsLoading="_database is null || _model is null">
     <EditForm Model="@_model" OnValidSubmit="OnSubmit">
         <DataAnnotationsValidator />
         <ValidationSummary />

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -44,11 +44,19 @@ public partial class Edit
     {
         _database = await DatabaseProvider.GetDatabase();
         _displaySettings = await SettingsProvider.GetDisplaySettings();
+        InitializeModel();
     }
 
     protected override void OnParametersSet()
     {
-        Debug.Assert(_database is not null);
+        InitializeModel();
+    }
+
+    private void InitializeModel()
+    {
+        if (_database is null)
+            return;
+
         var scheduledTransaction = _database.GetScheduledTransactionById(Id ?? DuplicatedScheduleTransactionId);
         if (scheduledTransaction is null && Id is not null)
         {

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Edit.razor.cs
@@ -44,7 +44,6 @@ public partial class Edit
     {
         _database = await DatabaseProvider.GetDatabase();
         _displaySettings = await SettingsProvider.GetDisplaySettings();
-        InitializeModel();
     }
 
     protected override void OnParametersSet()


### PR DESCRIPTION
When navigating to the scheduled transaction create/edit page, Blazor's `OnParametersSet` fires synchronously on the first render -- before `OnInitializedAsync` completes and the database is loaded. This left `_model` as `null`, causing `EditForm` to throw:

> EditForm requires either a Model parameter, or an EditContext parameter, please provide one of these.

**Changes:**

- Extracted model-initialization logic from `OnParametersSet` into a new `InitializeModel()` method.
- `InitializeModel()` is now called from `OnInitializedAsync` (after the database is ready) and from `OnParametersSet` (guarded with an early return when `_database is null`).
- Updated the `LoadingIndicator` condition in the razor from `_database is null` to `_database is null || _model is null`, so the `EditForm` is only rendered once both the database and the model are initialized.