### PR TITLE
Add "create next occurrence" action for scheduled transactions

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
@@ -45,6 +45,20 @@ public partial class Database
         ProcessScheduledTransactions(5);
     }
 
+    public void ProcessNextScheduledTransactionOccurrence(ScheduledTransaction scheduledTransaction)
+    {
+        using (DeferEvents())
+        {
+            if (scheduledTransaction.NextOccurenceDate is null)
+            {
+                ProcessScheduledTransaction(scheduledTransaction, GetToday().AddDays(1));
+                return;
+            }
+
+            ProcessScheduledTransaction(scheduledTransaction, scheduledTransaction.NextOccurenceDate.Value.AddDays(1));
+        }
+    }
+
     public void ProcessScheduledTransactions(int daysAhead)
     {
         using (DeferEvents())

--- a/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
@@ -47,14 +47,11 @@ public partial class Database
 
     public void ProcessNextScheduledTransactionOccurrence(ScheduledTransaction scheduledTransaction)
     {
+        if (scheduledTransaction.NextOccurenceDate is null)
+            return;
+
         using (DeferEvents())
         {
-            if (scheduledTransaction.NextOccurenceDate is null)
-            {
-                ProcessScheduledTransaction(scheduledTransaction, GetToday().AddDays(1));
-                return;
-            }
-
             ProcessScheduledTransaction(scheduledTransaction, scheduledTransaction.NextOccurenceDate.Value.AddDays(1));
         }
     }

--- a/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/ScheduledTransactions/Index.razor
@@ -54,6 +54,7 @@
             }
             <td class="commands">
                 <Dropdown>
+                    <li><button type="button" class="btn-link" @onclick="() => CreateNextOccurrence(scheduledTransaction)"><i class="fas fa-calendar-plus"></i> Create next occurrence</button></li>
                     <li><a class="duplicate" href="/scheduler/create?DuplicatedScheduleTransactionId=@scheduledTransaction.Id"><i class="fas fa-copy"></i> Duplicate</a></li>
                     <li><a class="edit" href="/scheduler/@scheduledTransaction.Id/edit"><i class="fas fa-pencil-alt"></i> Edit</a></li>
                     <li><button type="button" class="btn-link" @onclick="() => Delete(scheduledTransaction)"><i class="fas fa-trash" style="color: red"></i> Delete</button></li>
@@ -81,6 +82,13 @@
             database.RemoveScheduledTransaction(scheduledTransaction);
             await DatabaseProvider.Save();
         }
+    }
+
+    private async Task CreateNextOccurrence(ScheduledTransaction scheduledTransaction)
+    {
+        Debug.Assert(database != null);
+        database.ProcessNextScheduledTransactionOccurrence(scheduledTransaction);
+        await DatabaseProvider.Save();
     }
 
     private static string? FormatLabels(string[]? labels)

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -1288,6 +1288,12 @@ thead th {
   border-top: 0;
 }
 
+thead th a {
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
+}
+
 th, td {
   padding: 8px;
   text-align: left;


### PR DESCRIPTION
Scheduled transactions could only be generated by the global scheduler processing flow, which made it hard to manually create the next planned entry from the scheduler UI. This change adds a direct action to create the next occurrence from a schedule's context menu.

The scheduler row dropdown now includes a "Create next occurrence" action. It calls a new core database API that processes exactly one next occurrence for the selected scheduled transaction, reusing the existing recurrence processing logic so generated transactions, inter-account transfers, and recurrence advancement/removal stay consistent with current behavior.

This keeps the manual action small and behaviorally aligned with the existing scheduled transaction engine.