### PR TITLE
Polish search help link

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Analytics/Index.razor
@@ -69,11 +69,9 @@
 		}
 
 		<h2>Custom filter</h2>
-		<div class="input-group mb-3">
+		<div class="input-group mb-3 search-query-input-group">
 			<input type="text" value="@customFilter" @oninput="OnCustomFilter" class="form-control" placeholder="🔍 Search">
-			<div class="input-group-append">
-				<a class="input-group-text" href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-query-language.md" target="_blank" title="Search query language help">?</a>
-			</div>
+			<a class="search-query-help-link" href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-query-language.md" target="_blank" rel="noopener noreferrer" aria-label="Search query language help" title="Search query language help">?</a>
 		</div>
 
 		<h2>Period</h2>		<div class="form-group">

--- a/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Index.razor
@@ -63,11 +63,9 @@ else
     }
 </div>
 
-<div class="input-group mb-3">
+<div class="input-group mb-3 search-query-input-group">
     <input type="text" value="@Search" @oninput="OnSearch" class="form-control" placeholder="🔍 Search">
-    <div class="input-group-append">
-        <a class="input-group-text" href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-query-language.md" target="_blank" title="Search query language help">?</a>
-    </div>
+    <a class="search-query-help-link" href="https://github.com/meziantou/meziantou.moneiz/blob/main/doc/search-query-language.md" target="_blank" rel="noopener noreferrer" aria-label="Search query language help" title="Search query language help">?</a>
 </div>
 
 

--- a/src/Meziantou.Moneiz/wwwroot/css/_base.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/_base.css
@@ -73,6 +73,52 @@ a:hover {
   cursor: pointer;
 }
 
+.search-query-input-group {
+    display: flex;
+    align-items: stretch;
+    flex-wrap: nowrap;
+}
+
+.search-query-input-group .form-control {
+    flex: 1 1 auto;
+    min-width: 0;
+    border-right: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.search-query-help-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 38px;
+    padding: 0;
+    color: var(--text-muted, #666);
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 1;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-left: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    text-decoration: none;
+    transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.search-query-help-link:hover,
+.search-query-help-link:focus {
+    color: var(--link-color);
+    background-color: var(--hover-bg);
+    text-decoration: none;
+}
+
+.search-query-help-link:focus-visible {
+    outline: 2px solid var(--link-color);
+    outline-offset: -2px;
+}
+
 ul.unstyled > li {
     list-style: none;
 }

--- a/src/Meziantou.Moneiz/wwwroot/css/site.css
+++ b/src/Meziantou.Moneiz/wwwroot/css/site.css
@@ -73,6 +73,52 @@ a:hover {
   cursor: pointer;
 }
 
+.search-query-input-group {
+    display: flex;
+    align-items: stretch;
+    flex-wrap: nowrap;
+}
+
+.search-query-input-group .form-control {
+    flex: 1 1 auto;
+    min-width: 0;
+    border-right: none;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.search-query-help-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    width: 38px;
+    padding: 0;
+    color: var(--text-muted, #666);
+    font-size: 20px;
+    font-weight: 400;
+    line-height: 1;
+    background-color: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-left: none;
+    border-top-right-radius: 4px;
+    border-bottom-right-radius: 4px;
+    text-decoration: none;
+    transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.search-query-help-link:hover,
+.search-query-help-link:focus {
+    color: var(--link-color);
+    background-color: var(--hover-bg);
+    text-decoration: none;
+}
+
+.search-query-help-link:focus-visible {
+    outline: 2px solid var(--link-color);
+    outline-offset: -2px;
+}
+
 ul.unstyled > li {
     list-style: none;
 }


### PR DESCRIPTION
This improves the search help affordance next to the search fields so it reads as part of the input instead of a separate control below it.

The search inputs on the transactions and analytics pages now keep a compact help icon on the right in a single row, and the shared CSS constrains the input width so the link always has enough space without wrapping.