### PR TITLE
Add drag-and-drop position indicator for accounts

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.Account.cs
+++ b/src/Meziantou.Moneiz.Core/Database.Account.cs
@@ -62,6 +62,33 @@ public partial class Database
         return true;
     }
 
+    public bool MoveAccountAfter(Account account, Account targetAccount)
+    {
+        if (account == targetAccount || account.Closed != targetAccount.Closed)
+            return false;
+
+        var accounts = Accounts
+            .Where(a => a.Closed == account.Closed)
+            .OrderBy(a => a.SortOrder)
+            .ThenBy(a => a.Name, StringComparer.Ordinal)
+            .ToList();
+
+        if (!accounts.Contains(account) || !accounts.Contains(targetAccount))
+            return false;
+
+        _ = accounts.Remove(account);
+        var targetIndex = accounts.IndexOf(targetAccount);
+        accounts.Insert(targetIndex + 1, account);
+
+        for (var i = 0; i < accounts.Count; i++)
+        {
+            accounts[i].SortOrder = i;
+        }
+
+        RaiseDatabaseChanged();
+        return true;
+    }
+
     private void MoveAccount(Account account, int direction)
     {
         var accounts = Accounts.Sort().ToList();

--- a/src/Meziantou.Moneiz/Pages/Accounts/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Accounts/Index.razor
@@ -25,10 +25,12 @@
 
     <ItemTemplate Context="account">
         <tr @key="account.Id"
-            class="account-row @(draggedAccount == account ? "dragging" : "")"
+            class="@GetRowClass(account)"
             draggable="true"
             @ondragstart="() => OnDragStart(account)"
             @ondragend="OnDragEnd"
+            @ondragenter="() => OnDragEnter(account)"
+            @ondragleave="() => OnDragLeave(account)"
             @ondragover:preventDefault
             @ondrop:preventDefault
             @ondrop="() => OnDrop(account)">
@@ -65,9 +67,20 @@
     </ItemTemplate>
 </Repeater>
 
+<style>
+    .account-row.dragging {
+        opacity: 0.4;
+    }
+
+    .account-row.drop-before {
+        border-top: 3px solid var(--accent-color, #007acc);
+    }
+</style>
+
 @code {
     Database? database;
     Account? draggedAccount;
+    Account? dropTargetAccount;
 
     protected override async Task OnInitializedAsync()
     {
@@ -145,6 +158,16 @@
         }
     }
 
+    private string GetRowClass(Account account)
+    {
+        var classes = new System.Text.StringBuilder("account-row");
+        if (draggedAccount == account)
+            classes.Append(" dragging");
+        if (dropTargetAccount == account)
+            classes.Append(" drop-before");
+        return classes.ToString();
+    }
+
     private void OnDragStart(Account account)
     {
         draggedAccount = account;
@@ -153,6 +176,23 @@
     private void OnDragEnd()
     {
         draggedAccount = null;
+        dropTargetAccount = null;
+    }
+
+    private void OnDragEnter(Account account)
+    {
+        if (draggedAccount is null || draggedAccount == account)
+            return;
+
+        dropTargetAccount = account;
+    }
+
+    private void OnDragLeave(Account account)
+    {
+        if (dropTargetAccount == account)
+        {
+            dropTargetAccount = null;
+        }
     }
 
     private async Task OnDrop(Account targetAccount)
@@ -166,5 +206,6 @@
         }
 
         draggedAccount = null;
+        dropTargetAccount = null;
     }
 }

--- a/src/Meziantou.Moneiz/Pages/Accounts/Index.razor
+++ b/src/Meziantou.Moneiz/Pages/Accounts/Index.razor
@@ -1,4 +1,5 @@
-﻿@page "/accounts"
+﻿@inject IJSRuntime JS
+@page "/accounts"
 @inject DatabaseProvider DatabaseProvider
 
 <h1>Accounts</h1>
@@ -25,13 +26,14 @@
 
     <ItemTemplate Context="account">
         <tr @key="account.Id"
+            data-account-id="@account.Id"
             class="@GetRowClass(account)"
             draggable="true"
             @ondragstart="() => OnDragStart(account)"
             @ondragend="OnDragEnd"
-            @ondragenter="() => OnDragEnter(account)"
-            @ondragleave="() => OnDragLeave(account)"
             @ondragover:preventDefault
+            @ondragover="async (e) => await OnDragOver(e, account)"
+            @ondragleave="() => OnDragLeave(account)"
             @ondrop:preventDefault
             @ondrop="() => OnDrop(account)">
             <td class="drag-handle" title="Drag and drop to reorder">
@@ -75,12 +77,17 @@
     .account-row.drop-before {
         border-top: 3px solid var(--accent-color, #007acc);
     }
+
+    .account-row.drop-after {
+        border-bottom: 3px solid var(--accent-color, #007acc);
+    }
 </style>
 
 @code {
     Database? database;
     Account? draggedAccount;
     Account? dropTargetAccount;
+    bool dropAfter; // true = insert after target, false = insert before
 
     protected override async Task OnInitializedAsync()
     {
@@ -164,7 +171,7 @@
         if (draggedAccount == account)
             classes.Append(" dragging");
         if (dropTargetAccount == account)
-            classes.Append(" drop-before");
+            classes.Append(dropAfter ? " drop-after" : " drop-before");
         return classes.ToString();
     }
 
@@ -179,20 +186,20 @@
         dropTargetAccount = null;
     }
 
-    private void OnDragEnter(Account account)
+    private async Task OnDragOver(DragEventArgs e, Account account)
     {
         if (draggedAccount is null || draggedAccount == account)
             return;
 
+        var isBottomHalf = await JS.InvokeAsync<bool>("dragDropHelpers.isBottomHalf", e.ClientY, $"[data-account-id='{account.Id}']");
         dropTargetAccount = account;
+        dropAfter = isBottomHalf;
     }
 
     private void OnDragLeave(Account account)
     {
         if (dropTargetAccount == account)
-        {
             dropTargetAccount = null;
-        }
     }
 
     private async Task OnDrop(Account targetAccount)
@@ -200,7 +207,11 @@
         if (database is null || draggedAccount is null)
             return;
 
-        if (database.MoveAccountBefore(draggedAccount, targetAccount))
+        var moved = dropAfter
+            ? database.MoveAccountAfter(draggedAccount, targetAccount)
+            : database.MoveAccountBefore(draggedAccount, targetAccount);
+
+        if (moved)
         {
             await DatabaseProvider.Save();
         }

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -124,7 +124,7 @@ function MoneizFocusIfConnected(element) {
   }, 500);
 })()
 
-const dragDropHelpers = {
+window.dragDropHelpers = {
   isBottomHalf(clientY, selector) {
     const el = document.querySelector(selector);
     if (!el) return false;

--- a/src/Meziantou.Moneiz/wwwroot/js/interop.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/interop.js
@@ -123,3 +123,12 @@ function MoneizFocusIfConnected(element) {
     }
   }, 500);
 })()
+
+const dragDropHelpers = {
+  isBottomHalf(clientY, selector) {
+    const el = document.querySelector(selector);
+    if (!el) return false;
+    const rect = el.getBoundingClientRect();
+    return clientY > rect.top + rect.height / 2;
+  }
+};

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -171,6 +171,38 @@ public class DatabaseTests
     }
 
     [Fact]
+    public void MoveAccountAfterReordersAccounts()
+    {
+        var database = new Database();
+        var account1 = new Account { Name = "Account 1" };
+        var account2 = new Account { Name = "Account 2" };
+        var account3 = new Account { Name = "Account 3" };
+        database.SaveAccount(account1);
+        database.SaveAccount(account2);
+        database.SaveAccount(account3);
+
+        var updated = database.MoveAccountAfter(account1, account3);
+
+        Assert.True(updated);
+        Assert.Equal([account2, account3, account1], database.VisibleAccounts);
+    }
+
+    [Fact]
+    public void MoveAccountAfterDoesNotMoveAcrossOpenAndClosedAccounts()
+    {
+        var database = new Database();
+        var openedAccount = new Account { Name = "Opened account" };
+        var closedAccount = new Account { Name = "Closed account", Closed = true };
+        database.SaveAccount(openedAccount);
+        database.SaveAccount(closedAccount);
+
+        var updated = database.MoveAccountAfter(openedAccount, closedAccount);
+
+        Assert.False(updated);
+        Assert.Equal([openedAccount, closedAccount], database.Accounts.Sort());
+    }
+
+    [Fact]
     public void MoveAccountBeforeDoesNotMoveAcrossOpenAndClosedAccounts()
     {
         var database = new Database();


### PR DESCRIPTION
Dragging accounts to reorder them gave no visual feedback about where the item would land, making the operation feel unpredictable.

## What changed

**Visual indicator** -- hovering over a row during a drag now shows a colored border:
- Top half of a row: `border-top` (item will be inserted *before* that row)
- Bottom half of a row: `border-bottom` (item will be inserted *after* that row)

This is implemented by wiring `ondragover` to a small JS helper (`window.dragDropHelpers.isBottomHalf`) that checks the cursor's Y position relative to the hovered row's bounding rect, then toggling a `drop-before` or `drop-after` CSS class on the `<tr>`.

**Move-to-last support** -- previously dropping on the bottom row had no effect (it would only insert *before*, which is a no-op for the item already above it). A new `MoveAccountAfter` method on `Database` enables inserting after any target row, which is called when dropping on the bottom half of a row.

**Dragged row opacity** -- the row being dragged is faded to 40% so the rest of the list stays readable.

## Files changed

- `Database.Account.cs` -- adds `MoveAccountAfter`
- `DatabaseTests.cs` -- tests for `MoveAccountAfter` (reorder and cross-open/closed guard)
- `Pages/Accounts/Index.razor` -- wires `ondragover`, top/bottom detection, updated CSS classes
- `wwwroot/js/interop.js` -- adds `window.dragDropHelpers.isBottomHalf`