### PR TITLE
Fix scheduler next occurrence update

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
@@ -52,7 +52,7 @@ public partial class Database
 
         using (DeferEvents())
         {
-            ProcessScheduledTransaction(scheduledTransaction, scheduledTransaction.NextOccurenceDate.Value.AddDays(1));
+            ProcessScheduledTransaction(scheduledTransaction, scheduledTransaction.NextOccurenceDate.Value.AddDays(1), forceSingleOccurrence: true);
         }
     }
 
@@ -70,7 +70,7 @@ public partial class Database
         }
     }
 
-    private void ProcessScheduledTransaction(ScheduledTransaction scheduledTransaction, DateOnly createUntil)
+    private void ProcessScheduledTransaction(ScheduledTransaction scheduledTransaction, DateOnly createUntil, bool forceSingleOccurrence = false)
     {
         using (DeferEvents())
         {
@@ -94,7 +94,7 @@ public partial class Database
                 }
             }
 
-            while (scheduledTransaction.NextOccurenceDate < createUntil)
+            while (scheduledTransaction.NextOccurenceDate < createUntil || (forceSingleOccurrence && scheduledTransaction.NextOccurenceDate == createUntil))
             {
                 var transactionDate = scheduledTransaction.NextOccurenceDate.Value;
                 var interAccount = scheduledTransaction.CreditedAccount is not null;
@@ -147,6 +147,9 @@ public partial class Database
 
                 scheduledTransaction.NextOccurenceDate = newRecurrenceDate;
                 RaiseDatabaseChanged();
+
+                if (forceSingleOccurrence)
+                    return;
             }
         }
     }

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -98,6 +98,33 @@ public class DatabaseTests
     }
 
     [Fact]
+    public void ProcessNextScheduledTransactionOccurrence_UsesTheActualNextOccurrence()
+    {
+        var db = new Database();
+        var account = new Account();
+        db.SaveAccount(account);
+
+        var scheduledTransaction = new ScheduledTransaction
+        {
+            Account = account,
+            Amount = 1,
+            RecurrenceRuleText = "FREQ=MONTHLY;BYMONTHDAY=10",
+            Name = "test",
+            StartDate = new DateOnly(2026, 08, 10),
+            NextOccurenceDate = new DateOnly(2026, 08, 10),
+        };
+
+        db.SaveScheduledTransaction(scheduledTransaction);
+        db.Transactions.Clear();
+
+        db.ProcessNextScheduledTransactionOccurrence(scheduledTransaction);
+
+        var transaction = Assert.Single(db.Transactions);
+        Assert.Equal(new DateOnly(2026, 08, 10), transaction.ValueDate);
+        Assert.Equal(new DateOnly(2026, 09, 10), scheduledTransaction.NextOccurenceDate);
+    }
+
+    [Fact]
     public void GetPayeeSuggestionsMatchesAndRanksNames()
     {
         var account = new Account { Id = 1 };


### PR DESCRIPTION
When a scheduled transaction is created from the Scheduler page, the next occurrence should advance according to the recurrence rule. The current implementation only moved the processing window forward by one day, which left non-daily schedules with an incorrect next occurrence.

This change makes the manual "Create next occurrence" action process exactly the current scheduled occurrence, then recompute the following date from the recurrence rule. A regression test covers a monthly recurrence to ensure the next occurrence advances to the real next date instead of the next day.

Tests: `dotnet test tests/Meziantou.Moneiz.CoreTests/Meziantou.Moneiz.CoreTests.csproj --filter "FullyQualifiedName~DatabaseTests"`