### PR TITLE
Fix null model render on transaction edit form

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
+++ b/src/Meziantou.Moneiz/Pages/Transactions/Edit.razor
@@ -5,7 +5,7 @@
 
 <h1>Create transaction</h1>
 
-<LoadingIndicator IsLoading="database == null">
+<LoadingIndicator IsLoading="database is null || model is null">
 	<EditForm Model="@model" OnValidSubmit="OnSubmit">
 		<DataAnnotationsValidator />
 		<ValidationSummary />


### PR DESCRIPTION
Editing a transaction could throw at render time because `EditForm` was instantiated before the backing model was initialized. This caused an unhandled exception and blocked the edit flow.

The page now keeps showing the loading state until both the database and the transaction model are ready. This prevents `EditForm` from rendering with a null model and aligns the transaction edit page behavior with the scheduled transaction edit page.