### PR TITLE
Update Meziantou.NET.Sdk to 1.0.148

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,5 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="10.0.10" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
 </Project>

--- a/global.json
+++ b/global.json
@@ -3,9 +3,12 @@
     "version": "10.0.302",
     "rollForward": "patch"
   },
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.139",
-    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.139",
-    "Meziantou.NET.Sdk.Test": "1.0.139"
+    "Meziantou.NET.Sdk": "1.0.148",
+    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.148",
+    "Meziantou.NET.Sdk.Test": "1.0.148"
   }
 }

--- a/tests/Meziantou.Moneiz.CoreTests/Meziantou.Moneiz.CoreTests.csproj
+++ b/tests/Meziantou.Moneiz.CoreTests/Meziantou.Moneiz.CoreTests.csproj
@@ -1,14 +1,6 @@
 ﻿<Project Sdk="Meziantou.NET.Sdk.Test">
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3" />
-    <PackageReference Include="xunit.runner.visualstudio">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Meziantou.Moneiz.Core\Meziantou.Moneiz.Core.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` to 1.0.148 in `global.json`.

- Opt in to Microsoft Testing Platform via the `test.runner` setting in `global.json`
- Remove the `xunit.v3` / `xunit.runner.visualstudio` package references, now added by `Meziantou.NET.Sdk.Test`
