### PR TITLE
Update Meziantou.NET.Sdk to 1.0.149

### DIFF
--- a/global.json
+++ b/global.json
@@ -7,8 +7,8 @@
     "runner": "Microsoft.Testing.Platform"
   },
   "msbuild-sdks": {
-    "Meziantou.NET.Sdk": "1.0.148",
-    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.148",
-    "Meziantou.NET.Sdk.Test": "1.0.148"
+    "Meziantou.NET.Sdk": "1.0.149",
+    "Meziantou.NET.Sdk.BlazorWebAssembly": "1.0.149",
+    "Meziantou.NET.Sdk.Test": "1.0.149"
   }
 }

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -37,7 +37,7 @@ public class DatabaseTests
         _ = Assert.Single(imported.Accounts);
         _ = Assert.Single(imported.Categories);
         _ = Assert.Single(imported.Payees);
-        Assert.Equal(3, imported.Transactions.Count);
+        Assert.HasCount(3, imported.Transactions);
         Assert.NotEmpty(imported.Currencies);
 
         // Check references
@@ -72,7 +72,7 @@ public class DatabaseTests
         db.SaveScheduledTransaction(scheduledTransaction);
 
         // Assert
-        Assert.Equal(5, db.Transactions.Count);
+        Assert.HasCount(5, db.Transactions);
     }
 
     [Fact]


### PR DESCRIPTION
Update `Meziantou.NET.Sdk` from 1.0.148 to 1.0.149.

1.0.149 uses [`Meziantou.Framework.Assertions`](https://www.nuget.org/packages/Meziantou.Framework.Assertions) as the default assertion library, so `Assert` now refers to `Meziantou.Framework.Assertions.Assert` in the test projects.

Files changed:
- global.json
- tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs