### PR TITLE
Show an actionable error with a link to githubstatus.com when GitHub is down

### DIFF
--- a/src/Meziantou.Moneiz/Pages/Settings/DatabaseSettings.razor
+++ b/src/Meziantou.Moneiz/Pages/Settings/DatabaseSettings.razor
@@ -110,6 +110,10 @@
             await SaveGitHubConfig();
             await DatabaseProvider.ExportToGitHub();
         }
+        catch (GitHubUnavailableException)
+        {
+            // The error is displayed by the GitHubUnavailableWarning component
+        }
         finally
         {
             githubOperation = false;
@@ -123,6 +127,10 @@
             githubOperation = true;
             await SaveGitHubConfig();
             await DatabaseProvider.ImportFromGitHub(implicitLoad: false);
+        }
+        catch (GitHubUnavailableException)
+        {
+            // The error is displayed by the GitHubUnavailableWarning component
         }
         finally
         {

--- a/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
+++ b/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Meziantou.AspNetCore.Components.WebAssembly;
 using Meziantou.Framework;
@@ -16,11 +18,22 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
     private const string MoneizLocalStorageChangedName = "moneiz.dbchanged";
 
     private const string MoneizDownloadFileName = "moneiz.db";
+
+    private const string ImportOperation = "Cannot download the database from GitHub";
+    private const string ExportOperation = "Cannot save the database to GitHub";
+    private const string CheckNewVersionOperation = "Cannot check whether a new version of the database is available on GitHub";
+
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private Database? _database;
 
     public event EventHandler? DatabaseChanged;
     public event EventHandler? DatabaseSaved;
+    public event EventHandler? GitHubAvailabilityChanged;
+
+    /// <summary>
+    /// The last error raised because GitHub was unreachable or replied with a server error, or <see langword="null"/> when the last GitHub request succeeded.
+    /// </summary>
+    public GitHubUnavailableException? GitHubError { get; private set; }
 
     public void Dispose() => _semaphore.Dispose();
 
@@ -41,9 +54,14 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
                         {
                             await ImportFromGitHub(implicitLoad: true);
                         }
-                        catch (HttpRequestException ex) when (ex.StatusCode is System.Net.HttpStatusCode.Unauthorized)
+                        catch (HttpRequestException ex) when (ex.StatusCode is HttpStatusCode.Unauthorized)
                         {
                             navigationManager.NavigateTo("/database");
+                        }
+                        catch (GitHubUnavailableException ex)
+                        {
+                            // Keep using the local copy of the database. The error is displayed by the GitHubUnavailableWarning component.
+                            Console.WriteLine(ex.Message);
                         }
                     }
 
@@ -169,13 +187,13 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
         var configuration = await LoadConfiguration();
 
         using var httpClient = CreateClient(configuration);
-        var currentUser = await httpClient.GetFromJsonAsync<GitHubUser>("user");
+        var currentUser = await GetFromGitHubAsync<GitHubUser>(httpClient, "user", ExportOperation);
         if (currentUser is null)
             throw new InvalidOperationException("Cannot get current user");
 
         // https://developer.github.com/v3/repos/contents/#get-repository-content
         var url = "repos/" + currentUser.Login + "/" + configuration.GitHubRepository + "/contents/";
-        var files = await httpClient.GetFromJsonAsync<GitHubContent[]>(url);
+        var files = await GetFromGitHubAsync<GitHubContent[]>(httpClient, url, ExportOperation);
         if (files is null)
             throw new InvalidOperationException("Cannot get repository content");
 
@@ -189,14 +207,17 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
                 return;
         }
 
-        var putResult = await httpClient.PutAsJsonAsync(url + MoneizDownloadFileName, new
+        var putResult = await InvokeGitHubApi(ExportOperation, async () =>
         {
-            message = "save db",
-            content = bytes,
-            sha = file?.Sha,
-        });
+            var response = await httpClient.PutAsJsonAsync(url + MoneizDownloadFileName, new
+            {
+                message = "save db",
+                content = bytes,
+                sha = file?.Sha,
+            });
 
-        _ = putResult.EnsureSuccessStatusCode();
+            return response.EnsureSuccessStatusCode();
+        });
 
         file = (await putResult.Content.ReadFromJsonAsync<UpdateFileResult>())?.Content;
 
@@ -215,18 +236,27 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
 
         var configuration = await LoadConfiguration();
         using var httpClient = CreateClient(configuration);
-        var currentUser = await httpClient.GetFromJsonAsync<GitHubUser>("user");
-        if (currentUser is null)
-            throw new InvalidOperationException("Cannot get current user");
+        try
+        {
+            var currentUser = await GetFromGitHubAsync<GitHubUser>(httpClient, "user", CheckNewVersionOperation);
+            if (currentUser is null)
+                throw new InvalidOperationException("Cannot get current user");
 
-        // https://developer.github.com/v3/repos/contents/#get-repository-content
-        var url = "repos/" + currentUser.Login + "/" + configuration.GitHubRepository + "/contents/";
-        var files = await SafeGetForJsonAsync<GitHubContent[]>(httpClient, url);
-        var file = files?.FirstOrDefault(f => f.Name == MoneizDownloadFileName);
-        if ((file is not null && configuration.GitHubSha is null) || file is null || !file.Sha.EqualsIgnoreCase(configuration.GitHubSha))
-            return true;
+            // https://developer.github.com/v3/repos/contents/#get-repository-content
+            var url = "repos/" + currentUser.Login + "/" + configuration.GitHubRepository + "/contents/";
+            var files = await SafeGetFromGitHubAsync<GitHubContent[]>(httpClient, url, CheckNewVersionOperation);
+            var file = files?.FirstOrDefault(f => f.Name == MoneizDownloadFileName);
+            if ((file is not null && configuration.GitHubSha is null) || file is null || !file.Sha.EqualsIgnoreCase(configuration.GitHubSha))
+                return true;
 
-        return false;
+            return false;
+        }
+        catch (GitHubUnavailableException ex)
+        {
+            // This runs in the background, so the error is only reported by the GitHubUnavailableWarning component
+            Console.WriteLine(ex.Message);
+            return false;
+        }
     }
 
     public async Task ImportFromGitHub(bool implicitLoad)
@@ -240,13 +270,13 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
         var configuration = await LoadConfiguration();
 
         using var httpClient = CreateClient(configuration);
-        var currentUser = await httpClient.GetFromJsonAsync<GitHubUser>("user");
+        var currentUser = await GetFromGitHubAsync<GitHubUser>(httpClient, "user", ImportOperation);
         if (currentUser is null)
             throw new InvalidOperationException("Cannot get current user");
 
         // https://developer.github.com/v3/repos/contents/#get-repository-content
         var url = "repos/" + currentUser.Login + "/" + configuration.GitHubRepository + "/contents/";
-        var files = await SafeGetForJsonAsync<GitHubContent[]>(httpClient, url);
+        var files = await SafeGetFromGitHubAsync<GitHubContent[]>(httpClient, url, ImportOperation);
         var file = files?.FirstOrDefault(f => f.Name == MoneizDownloadFileName);
         if (file is null)
         {
@@ -277,12 +307,9 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
 
         // Cannot use Download url for private repository
         // /repos/:owner/:repo/git/blobs/:file_sha
-        var blob = await httpClient.GetFromJsonAsync<GitHubBlob>("repos/" + currentUser.Login + "/" + configuration.GitHubRepository + "/git/blobs/" + file.Sha);
-        if (blob is null)
-            throw new InvalidOperationException("Cannot download database from GitHub");
-
-        if (blob.Content is null)
-            throw new InvalidOperationException("Cannot download database from GitHub");
+        var blob = await GetFromGitHubAsync<GitHubBlob>(httpClient, "repos/" + currentUser.Login + "/" + configuration.GitHubRepository + "/git/blobs/" + file.Sha, ImportOperation);
+        if (blob?.Content is null)
+            throw new InvalidOperationException(ImportOperation + ": GitHub returned an empty file.");
 
         var data = Convert.FromBase64String(blob.Content);
         var database = await Database.Load(data);
@@ -291,11 +318,15 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
         await SetConfiguration(configuration);
     }
 
-    private static async Task<T?> SafeGetForJsonAsync<T>(HttpClient httpClient, string url) where T : class
+    /// <summary>
+    /// Same as <see cref="GetFromGitHubAsync{T}(HttpClient, string, string)"/> but returns <see langword="null"/> when GitHub answers with a client
+    /// error (unknown repository, missing permission, …). Errors indicating GitHub is down are still reported.
+    /// </summary>
+    private async Task<T?> SafeGetFromGitHubAsync<T>(HttpClient httpClient, string url, string operation) where T : class
     {
         try
         {
-            return await httpClient.GetFromJsonAsync<T>(url);
+            return await GetFromGitHubAsync<T>(httpClient, url, operation);
         }
         catch (HttpRequestException)
         {
@@ -303,13 +334,53 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
         }
     }
 
+    private Task<T?> GetFromGitHubAsync<T>(HttpClient httpClient, string url, string operation) where T : class
+        => InvokeGitHubApi(operation, () => httpClient.GetFromJsonAsync<T>(url));
+
+    /// <summary>
+    /// Converts the failures indicating GitHub is down to a <see cref="GitHubUnavailableException"/>, so the user gets an actionable
+    /// error message instead of a raw HTTP error. Other failures (bad token, unknown repository, …) are not altered.
+    /// </summary>
+    private async Task<T> InvokeGitHubApi<T>(string operation, Func<Task<T>> action)
+    {
+        try
+        {
+            var result = await action();
+            SetGitHubError(error: null);
+            return result;
+        }
+        catch (HttpRequestException ex) when (ex.StatusCode is null or >= HttpStatusCode.InternalServerError)
+        {
+            // No status code means the request didn't reach GitHub (offline, DNS failure, GitHub down, …)
+            var exception = GitHubUnavailableException.Create(operation, ex.StatusCode, ex);
+            SetGitHubError(exception);
+            throw exception;
+        }
+        catch (Exception ex) when (ex is JsonException or NotSupportedException)
+        {
+            // GitHub returns an HTML page instead of JSON when it is down
+            var exception = GitHubUnavailableException.CreateInvalidResponse(operation, ex);
+            SetGitHubError(exception);
+            throw exception;
+        }
+    }
+
+    private void SetGitHubError(GitHubUnavailableException? error)
+    {
+        if (GitHubError is null && error is null)
+            return;
+
+        GitHubError = error;
+        GitHubAvailabilityChanged?.Invoke(this, EventArgs.Empty);
+    }
+
     public async Task OpenGitHubRepository()
     {
         var configuration = await LoadConfiguration();
 
         using var httpClient = CreateClient(configuration);
-        var currentUser = await httpClient.GetFromJsonAsync<GitHubUser>("user");
-        if(currentUser is null)
+        var currentUser = await GetFromGitHubAsync<GitHubUser>(httpClient, "user", "Cannot open the GitHub repository");
+        if (currentUser is null)
             throw new InvalidOperationException("Cannot get current user");
 
         var url = "https://github.com/" + currentUser.Login + "/" + configuration.GitHubRepository;

--- a/src/Meziantou.Moneiz/Services/GitHubUnavailableException.cs
+++ b/src/Meziantou.Moneiz/Services/GitHubUnavailableException.cs
@@ -1,0 +1,70 @@
+using System.Net;
+
+namespace Meziantou.Moneiz.Services;
+
+/// <summary>
+/// Thrown when a GitHub operation fails because GitHub itself is unreachable or replies with a server error,
+/// as opposed to a failure caused by the token, the repository name, or the content of the database.
+/// </summary>
+public sealed class GitHubUnavailableException : Exception
+{
+    /// <summary>
+    /// The GitHub status page. It is displayed to the user so they can check for an ongoing incident.
+    /// </summary>
+    public const string StatusPageUrl = "https://www.githubstatus.com";
+
+    public GitHubUnavailableException()
+    {
+    }
+
+    public GitHubUnavailableException(string message) : base(message)
+    {
+    }
+
+    public GitHubUnavailableException(string message, Exception? innerException) : base(message, innerException)
+    {
+    }
+
+    public GitHubUnavailableException(string message, HttpStatusCode? statusCode, Exception? innerException) : base(message, innerException) => StatusCode = statusCode;
+
+    /// <summary>
+    /// The status code returned by GitHub, or <see langword="null"/> when GitHub could not be reached at all.
+    /// </summary>
+    public HttpStatusCode? StatusCode { get; }
+
+    /// <summary>
+    /// The operation that failed, such as "Cannot download the database from GitHub". <see langword="null"/> when the exception was not created by <see cref="Create"/> or <see cref="CreateInvalidResponse"/>.
+    /// </summary>
+    public string? Operation { get; private init; }
+
+    /// <summary>
+    /// The explanation of the failure, without the <see cref="Operation"/>. <see langword="null"/> when the exception was not created by <see cref="Create"/> or <see cref="CreateInvalidResponse"/>.
+    /// </summary>
+    public string? Details { get; private init; }
+
+    public static GitHubUnavailableException Create(string operation, HttpStatusCode? statusCode, Exception? innerException)
+    {
+        var reason = statusCode switch
+        {
+            null => "GitHub could not be reached. GitHub may be down, or this device may be offline.",
+            HttpStatusCode.ServiceUnavailable => "GitHub is temporarily unavailable (HTTP 503 Service Unavailable). This usually means GitHub is down.",
+            HttpStatusCode.BadGateway or HttpStatusCode.GatewayTimeout => $"GitHub did not answer in time (HTTP {(int)statusCode.Value} {statusCode}). This usually means GitHub is down.",
+            _ => $"GitHub replied with an unexpected error (HTTP {(int)statusCode.Value} {statusCode}).",
+        };
+
+        return CreateCore(operation, reason, statusCode, innerException);
+    }
+
+    public static GitHubUnavailableException CreateInvalidResponse(string operation, Exception? innerException)
+        => CreateCore(operation, "GitHub replied with an unexpected response instead of the expected data. This usually means GitHub is down or that a network device altered the response.", statusCode: null, innerException);
+
+    private static GitHubUnavailableException CreateCore(string operation, string reason, HttpStatusCode? statusCode, Exception? innerException)
+    {
+        var details = reason + " Nothing was changed on this device, so you can safely retry once GitHub is back.";
+        return new GitHubUnavailableException($"{operation}: {details}", statusCode, innerException)
+        {
+            Operation = operation,
+            Details = details,
+        };
+    }
+}

--- a/src/Meziantou.Moneiz/Shared/DatabaseNotExported.razor
+++ b/src/Meziantou.Moneiz/Shared/DatabaseNotExported.razor
@@ -74,6 +74,10 @@
         {
             await DatabaseProvider.ExportToGitHub();
         }
+        catch (GitHubUnavailableException)
+        {
+            // The error is displayed by the GitHubUnavailableWarning component
+        }
         finally
         {
             isExporting = false;

--- a/src/Meziantou.Moneiz/Shared/GitHubUnavailableWarning.razor
+++ b/src/Meziantou.Moneiz/Shared/GitHubUnavailableWarning.razor
@@ -1,0 +1,51 @@
+@inject DatabaseProvider DatabaseProvider
+@implements IDisposable
+
+@if (error is not null && !dismissed)
+{
+    <div class="github-unavailable-container">
+        <div class="container">
+            <div class="alert alert-danger github-unavailable">
+                <i class="fas fa-exclamation-triangle"></i>
+                <span>
+                    <strong>@(error.Operation ?? "Cannot synchronize the database with GitHub")</strong>
+                    <text> — @(error.Details ?? error.Message) Check </text>
+                    <a href="@GitHubUnavailableException.StatusPageUrl" target="_blank" rel="noopener noreferrer">@GitHubUnavailableException.StatusPageUrl</a>
+                    <text> to know if there is an ongoing GitHub incident.</text>
+                </span>
+                <button type="button" class="github-unavailable-dismiss" title="Dismiss" @onclick="Dismiss"><i class="fas fa-times"></i></button>
+            </div>
+        </div>
+    </div>
+}
+
+@code {
+    private GitHubUnavailableException? error;
+    private bool dismissed;
+
+    protected override void OnInitialized()
+    {
+        DatabaseProvider.GitHubAvailabilityChanged += OnGitHubAvailabilityChanged;
+        error = DatabaseProvider.GitHubError;
+    }
+
+    public void Dispose()
+    {
+        DatabaseProvider.GitHubAvailabilityChanged -= OnGitHubAvailabilityChanged;
+    }
+
+    private void OnGitHubAvailabilityChanged(object? sender, EventArgs e)
+    {
+        InvokeAsync(() =>
+        {
+            error = DatabaseProvider.GitHubError;
+            dismissed = false;
+            StateHasChanged();
+        });
+    }
+
+    private void Dismiss()
+    {
+        dismissed = true;
+    }
+}

--- a/src/Meziantou.Moneiz/Shared/GitHubUnavailableWarning.razor.css
+++ b/src/Meziantou.Moneiz/Shared/GitHubUnavailableWarning.razor.css
@@ -1,0 +1,56 @@
+.github-unavailable-container {
+    background-color: #f2dede;
+    border-bottom: 1px solid #ebccd1;
+}
+
+.github-unavailable {
+    background-color: #f2dede;
+    border: none;
+    border-left: 4px solid #d9534f;
+    color: #a94442;
+    padding: 12px 20px;
+    margin: 0;
+    border-radius: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.github-unavailable i {
+    color: #d9534f;
+    font-size: 16px;
+}
+
+.github-unavailable strong {
+    font-weight: 700;
+}
+
+.github-unavailable a {
+    color: #a94442;
+    text-decoration: underline;
+}
+
+.github-unavailable a:hover {
+    color: #843534;
+}
+
+.github-unavailable-dismiss {
+    background: none;
+    border: none;
+    color: #a94442;
+    cursor: pointer;
+    margin-left: auto;
+    padding: 0 4px;
+}
+
+.alert {
+    padding: 15px;
+    border: 1px solid transparent;
+    border-radius: 4px;
+}
+
+.alert-danger {
+    background-color: #f2dede;
+    border-color: #ebccd1;
+    color: #a94442;
+}

--- a/src/Meziantou.Moneiz/Shared/MainLayout.razor
+++ b/src/Meziantou.Moneiz/Shared/MainLayout.razor
@@ -30,6 +30,8 @@
         </div>
     </header>
 
+    <GitHubUnavailableWarning />
+
     <OverdraftWarning />
 
     <div class="grid-container container @(sidebarCollapsed ? "sidebar-collapsed" : "")" style="@(sidebarMaxWidth.HasValue ? $"--sidebar-max-width: {sidebarMaxWidth.Value}px" : "")">


### PR DESCRIPTION
## Why

When GitHub is down (unreachable, 5xx, or answering with an HTML error page instead of JSON), downloading the database failed in an unhelpful way:

- the explicit "Import from GitHub" button raised the generic Blazor `An unhandled error has occurred` bar;
- listing the repository content swallowed the failure and alerted `No database found on GitHub`, which is misleading and could push the user to overwrite a database that is actually there;
- with auto-load enabled, the exception escaped `GetDatabase()` at startup, and the background version check (`async void`, every 60s) threw as well.

## What changed

- **`GitHubUnavailableException`** (new): distinguishes "GitHub is down" from "your token/repository is wrong". It carries the failed operation, an explanation that depends on the cause (unreachable, 503, 502/504, other 5xx, unparsable response), and the `https://www.githubstatus.com` URL.
- **`DatabaseProvider`**: every GitHub call (current user, repository content, blob download, file upload) goes through `InvokeGitHubApi`, which converts network failures, 5xx replies, `JsonException`/`NotSupportedException` into that exception and tracks `GitHubError` + a `GitHubAvailabilityChanged` event. `SafeGetForJsonAsync` no longer hides outages behind a `null` result — only genuine client errors (404/403) still return `null`. The startup auto-load and the background version check catch the exception, log it, and keep using the local database.
- **`GitHubUnavailableWarning`** (new component, added to `MainLayout`): dismissible banner showing the message and a clickable link to githubstatus.com. It reappears when a new failure happens and disappears once a GitHub request succeeds.
- **`DatabaseSettings` / `DatabaseNotExported`**: catch the exception so an outage shows the banner instead of the crash bar.

Example of the rendered text:

> **Cannot download the database from GitHub** — GitHub is temporarily unavailable (HTTP 503 Service Unavailable). This usually means GitHub is down. Nothing was changed on this device, so you can safely retry once GitHub is back. Check https://www.githubstatus.com to know if there is an ongoing GitHub incident.

Errors caused by the user's configuration (invalid token → 401, unknown repository → 404) keep their previous behavior.

## Verification

- `dotnet build Meziantou.Moneiz.slnx`: 0 warnings, 0 errors.
- `dotnet test Meziantou.Moneiz.slnx`: 21/21 passed.
- Ran the app locally with the GitHub base address temporarily pointed at a dead port and then at a local server returning `503`, and checked: the banner renders on startup auto-load, on explicit import, and on export; the app still loads the local database; dismiss works; the background check logs instead of crashing. The base address change was reverted before committing.