### PR TITLE
Fix NaN chart coordinates for flat and single-day balance histories

### DIFF
--- a/src/Meziantou.Moneiz/wwwroot/js/charts.js
+++ b/src/Meziantou.Moneiz/wwwroot/js/charts.js
@@ -71,13 +71,25 @@ window.MoneizCharts = {
                 });
             });
 
+            // A constant series (or no data at all) has no range, which would turn every
+            // vertical coordinate into NaN, so fall back to an arbitrary non-zero range
+            if (!Number.isFinite(minValue) || !Number.isFinite(maxValue)) {
+                minValue = 0;
+                maxValue = 1;
+            }
+
             // Add some padding to the range
             const valueRange = maxValue - minValue;
-            minValue = minValue - valueRange * 0.1;
-            maxValue = maxValue + valueRange * 0.1;
+            const valuePadding = valueRange > 0 ? valueRange * 0.1 : Math.max(Math.abs(maxValue) * 0.1, 1);
+            minValue = minValue - valuePadding;
+            maxValue = maxValue + valuePadding;
 
             // Helper functions
-            const getX = (index) => padding.left + (index / (labels.length - 1)) * chartWidth;
+            // A single point has no horizontal range, so center it instead of dividing by zero
+            const lastIndex = labels.length - 1;
+            const getX = (index) => lastIndex > 0
+                ? padding.left + (index / lastIndex) * chartWidth
+                : padding.left + chartWidth / 2;
             const getY = (value) => padding.top + chartHeight - ((value - minValue) / (maxValue - minValue)) * chartHeight;
 
             // Theme colors


### PR DESCRIPTION
## What

The balance history chart produced `NaN` coordinates in two degenerate cases, so valid data silently failed to render:

- **Flat series.** A constant balance makes `maxValue - minValue` zero, so `getY` computed `0/0`. Any account with no transactions in the selected range hits this.
- **Single-day range.** A start date equal to the end date makes `labels.length - 1` zero, so `getX` computed `index/0`.

## How

In `createLineChart`:

- The range padding is `valueRange * 0.1` only when the range is positive. A flat series falls back to `max(|value| * 0.1, 1)`, so a flat 1000 series renders in a 900–1100 window and a flat 0 series in −1…1.
- A lone point is centered in the plot area instead of dividing by a zero index span.
- Also guarded the fully-empty case: with no data point at all, `minValue`/`maxValue` stayed at ±`Infinity` and the Y axis printed literal `NaN` labels. Those bounds now fall back to 0…1.

## Verification

Ran the real `createLineChart` under `node`'s `vm` with a stubbed canvas, recording every coordinate passed to `moveTo`/`lineTo`/`arc`/`fillText` plus the `getX`/`getY` values the tooltip hit-test uses. Before the change: flat series, flat-at-zero, single day, single-day flat, no data points, no dataset, and two flat datasets all emitted non-finite coordinates. After: all finite.

A normal 30-point series produces an identical sequence of canvas calls before and after, so existing rendering does not shift.

The 21 Core tests pass (21/21).

## Notes for the reviewer

- `dotnet test` reports "Zero tests ran" (exit 5) in my environment even at `main`; running the test executable directly runs and passes all 21. Unrelated to this change.
- The `Meziantou.Moneiz` WASM project could not be built locally — `NETSDK1147: the following workloads must be installed: wasm-tools`. Also pre-existing, and this change touches only a static `wwwroot` JS file with no C# compilation impact, so CI covers the build.