### PR TITLE
Index database entities when loading instead of scanning collections

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.cs
+++ b/src/Meziantou.Moneiz.Core/Database.cs
@@ -94,37 +94,38 @@ public sealed partial class Database
         if (db is null)
             throw new Exception("database is null");
 
-        db.ResolveReferences();
-        db.AssertNoDetachedReferences();
+        var index = new DatabaseReferenceIndex(db);
+        db.ResolveReferences(index);
+        db.AssertNoDetachedReferences(index);
         db.ProcessScheduledTransactions();
         return db;
     }
 
-    private void ResolveReferences()
+    private void ResolveReferences(DatabaseReferenceIndex index)
     {
         foreach (var payee in Payees)
         {
-            payee.ResolveReferences(this);
+            payee.ResolveReferences(index);
         }
 
         foreach (var transaction in Transactions)
         {
-            transaction.ResolveReferences(this);
+            transaction.ResolveReferences(index);
         }
 
         foreach (var scheduledTransaction in ScheduledTransactions)
         {
-            scheduledTransaction.ResolveReferences(this);
+            scheduledTransaction.ResolveReferences(index);
         }
     }
 
-    private void AssertNoDetachedReferences()
+    private void AssertNoDetachedReferences(DatabaseReferenceIndex index)
     {
         foreach (var payee in Payees)
         {
             if (payee.DefaultCategory is not null)
             {
-                if (!Categories.Any(c => ReferenceEquals(c, payee.DefaultCategory)))
+                if (!index.Categories.Contains(payee.DefaultCategory))
                     throw new MoneizException($"Database is not valid: category of payee '{payee}' is not valid");
             }
         }
@@ -133,19 +134,19 @@ public sealed partial class Database
         {
             if (transaction.Account is not null)
             {
-                if (!Accounts.Any(c => ReferenceEquals(c, transaction.Account)))
+                if (!index.Accounts.Contains(transaction.Account))
                     throw new MoneizException($"Database is not valid: account of transaction '{transaction.Id}' is not valid");
             }
 
             if (transaction.Category is not null)
             {
-                if (!Categories.Any(c => ReferenceEquals(c, transaction.Category)))
+                if (!index.Categories.Contains(transaction.Category))
                     throw new MoneizException($"Database is not valid: category of transaction '{transaction.Id}' is not valid");
             }
 
             if (transaction.Payee is not null)
             {
-                if (!Payees.Any(c => ReferenceEquals(c, transaction.Payee)))
+                if (!index.Payees.Contains(transaction.Payee))
                     throw new MoneizException($"Database is not valid: payee of transaction '{transaction.Id}' is not valid");
             }
 
@@ -154,7 +155,7 @@ public sealed partial class Database
                 if (!ReferenceEquals(transaction.LinkedTransaction.LinkedTransaction, transaction))
                     throw new MoneizException($"Database is not valid: linked transaction of transaction '{transaction.Id}' is not valid");
 
-                if (!Transactions.Any(c => ReferenceEquals(c, transaction.LinkedTransaction)))
+                if (!index.Transactions.Contains(transaction.LinkedTransaction))
                     throw new MoneizException($"Database is not valid: linked transaction of transaction '{transaction.Id}' is not valid");
             }
         }

--- a/src/Meziantou.Moneiz.Core/DatabaseReferenceIndex.cs
+++ b/src/Meziantou.Moneiz.Core/DatabaseReferenceIndex.cs
@@ -1,0 +1,44 @@
+﻿namespace Meziantou.Moneiz.Core;
+
+/// <summary>
+/// Indexes the entities of a <see cref="Database"/> by id and by instance, so references can be resolved and validated
+/// without scanning the whole collections for every entity.
+/// </summary>
+internal sealed class DatabaseReferenceIndex
+{
+    public DatabaseReferenceIndex(Database database)
+    {
+        Accounts = new EntityIndex<Account>(database.Accounts, item => item.Id);
+        Categories = new EntityIndex<Category>(database.Categories, item => item.Id);
+        Payees = new EntityIndex<Payee>(database.Payees, item => item.Id);
+        Transactions = new EntityIndex<Transaction>(database.Transactions, item => item.Id);
+    }
+
+    public EntityIndex<Account> Accounts { get; }
+
+    public EntityIndex<Category> Categories { get; }
+
+    public EntityIndex<Payee> Payees { get; }
+
+    public EntityIndex<Transaction> Transactions { get; }
+}
+
+internal sealed class EntityIndex<T> where T : class
+{
+    private readonly Dictionary<int, T> _itemsById = [];
+    private readonly HashSet<object> _items = new(ReferenceEqualityComparer.Instance);
+
+    public EntityIndex(IEnumerable<T> items, Func<T, int> idSelector)
+    {
+        foreach (var item in items)
+        {
+            // Keep the first item of a given id, so the lookup behaves like the sequential search it replaces
+            _ = _itemsById.TryAdd(idSelector(item), item);
+            _ = _items.Add(item);
+        }
+    }
+
+    public T? GetById(int? id) => id is int value && _itemsById.TryGetValue(value, out var item) ? item : null;
+
+    public bool Contains(T item) => _items.Contains(item);
+}

--- a/src/Meziantou.Moneiz.Core/Payee.cs
+++ b/src/Meziantou.Moneiz.Core/Payee.cs
@@ -30,11 +30,11 @@ public sealed class Payee
         set => _defaultCategoryId = value;
     }
 
-    internal void ResolveReferences(Database database)
+    internal void ResolveReferences(DatabaseReferenceIndex index)
     {
         if (_defaultCategoryId.HasValue)
         {
-            DefaultCategory = database.GetCategoryById(_defaultCategoryId);
+            DefaultCategory = index.Categories.GetById(_defaultCategoryId);
         }
     }
 

--- a/src/Meziantou.Moneiz.Core/ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/ScheduledTransaction.cs
@@ -128,26 +128,26 @@ public sealed class ScheduledTransaction
         return RecurrenceRule.GetNextOccurrences(NextOccurenceDate.Value.ToDateTime(TimeOnly.MinValue));
     }
 
-    internal void ResolveReferences(Database database)
+    internal void ResolveReferences(DatabaseReferenceIndex index)
     {
         if (_accountId.HasValue)
         {
-            Account = database.GetAccountById(_accountId);
+            Account = index.Accounts.GetById(_accountId);
         }
 
         if (_creditedAccountId.HasValue)
         {
-            CreditedAccount = database.GetAccountById(_creditedAccountId);
+            CreditedAccount = index.Accounts.GetById(_creditedAccountId);
         }
 
         if (_payeeId.HasValue)
         {
-            Payee = database.GetPayeeById(_payeeId);
+            Payee = index.Payees.GetById(_payeeId);
         }
 
         if (_categoryId.HasValue)
         {
-            Category = database.GetCategoryById(_categoryId);
+            Category = index.Categories.GetById(_categoryId);
         }
     }
 }

--- a/src/Meziantou.Moneiz.Core/Transaction.cs
+++ b/src/Meziantou.Moneiz.Core/Transaction.cs
@@ -122,26 +122,26 @@ public sealed class Transaction
         }
     }
 
-    internal void ResolveReferences(Database database)
+    internal void ResolveReferences(DatabaseReferenceIndex index)
     {
         if (_accountId.HasValue)
         {
-            Account = database.GetAccountById(_accountId);
+            Account = index.Accounts.GetById(_accountId);
         }
 
         if (_payeeId.HasValue)
         {
-            Payee = database.GetPayeeById(_payeeId);
+            Payee = index.Payees.GetById(_payeeId);
         }
 
         if (_categoryId.HasValue)
         {
-            Category = database.GetCategoryById(_categoryId);
+            Category = index.Categories.GetById(_categoryId);
         }
 
         if (_linkedTransactionId.HasValue)
         {
-            LinkedTransaction = database.GetTransactionById(_linkedTransactionId);
+            LinkedTransaction = index.Transactions.GetById(_linkedTransactionId);
         }
     }
 }

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -53,6 +53,43 @@ public class DatabaseTests
     }
 
     [Fact]
+    public async Task ImportExportResolvesEveryTransferReference()
+    {
+        const int TransferCount = 500;
+
+        var today = Database.GetToday();
+        var debitedAccount = new Account { Id = 1, Name = "a1", CurrencyIsoCode = "USD" };
+        var creditedAccount = new Account { Id = 2, Name = "a2", CurrencyIsoCode = "USD" };
+        var database = new Database()
+        {
+            Accounts = { debitedAccount, creditedAccount },
+        };
+
+        for (var i = 0; i < TransferCount; i++)
+        {
+            var debit = new Transaction { Id = (i * 2) + 1, Account = debitedAccount, Amount = -10, ValueDate = today };
+            var credit = new Transaction { Id = (i * 2) + 2, Account = creditedAccount, Amount = 10, ValueDate = today };
+            debit.LinkedTransaction = credit;
+            credit.LinkedTransaction = debit;
+            database.Transactions.Add(debit);
+            database.Transactions.Add(credit);
+        }
+
+        var imported = await Database.Load(database.Export());
+
+        Assert.HasCount(TransferCount * 2, imported.Transactions);
+        foreach (var transaction in imported.Transactions)
+        {
+            var linkedTransaction = transaction.LinkedTransaction;
+            Assert.NotNull(linkedTransaction);
+            Assert.Equal(transaction.Amount < 0 ? transaction.Id + 1 : transaction.Id - 1, linkedTransaction.Id);
+            Assert.Same(transaction, linkedTransaction.LinkedTransaction);
+            Assert.Contains(linkedTransaction, imported.Transactions);
+            Assert.Same(transaction.Amount < 0 ? imported.GetAccountById(1) : imported.GetAccountById(2), transaction.Account);
+        }
+    }
+
+    [Fact]
     public void AddScheduledTransaction()
     {
         var db = new Database();


### PR DESCRIPTION
## Problem

Loading a transfer-heavy database scales quadratically with the number of transactions.

While loading, each entity resolved its references with a sequential search over the whole collection (`Transactions.FirstOrDefault(item => item.Id == id)`), and `AssertNoDetachedReferences` then scanned the collection a second time per reference (`Transactions.Any(c => ReferenceEquals(c, ...))`). With a substantial proportion of linked transfers, both passes are O(n²).

Reproduced locally with `Database.Load` on a synthetic database of linked transfers (Release, after a warmup):

| Linked transactions | Load time |
| ---: | ---: |
| 5,000 | 62 ms |
| 10,000 | 111 ms |
| 20,000 | 398 ms |
| 40,000 | 1,628 ms |

## Change

- New internal `DatabaseReferenceIndex`, built once per load, holding an `EntityIndex<T>` per entity type: a `Dictionary<int, T>` for id lookups and a `HashSet<object>` with reference equality for membership checks.
- `Database.ResolveReferences` / `AssertNoDetachedReferences` take the index; the four `Any(c => ReferenceEquals(...))` scans became `index.<Collection>.Contains(...)`.
- `Transaction`, `ScheduledTransaction` and `Payee` resolve their references through the index instead of the `Database.Get*ById` linear scans.

After the change, doubling the transaction count roughly doubles the load time instead of quadrupling it:

| Linked transactions | Before | After |
| ---: | ---: | ---: |
| 5,000 | 62 ms | 12 ms |
| 10,000 | 111 ms | 10 ms |
| 20,000 | 398 ms | 19 ms |
| 40,000 | 1,628 ms | 43 ms |

## Notes for reviewers

- The index keeps the **first** entity for a duplicated id (`TryAdd`), so lookups behave exactly like the `FirstOrDefault` searches they replace. Membership checks use a reference set rather than the dictionary, so validation semantics are unchanged even in the duplicate-id case.
- The index exists only for the duration of `Database.Load` and is discarded before `ProcessScheduledTransactions` mutates the collections — there is no long-lived cache that could go stale against later edits.
- The public `Database.GetTransactionById` / `GetAccountById` / … helpers are untouched; only the `internal` load path changed, so the Blazor app and CLI are unaffected.

## Testing

- `Meziantou.Moneiz.Core` and `Meziantou.Moneiz.Cli` build with 0 warnings / 0 errors.
- Core test suite passes: 22 tests (21 existing + 1 new). The new `DatabaseTests.ImportExportResolvesEveryTransferReference` round-trips 1,000 transfer transactions and asserts every link, back-link and account reference resolves to the right instance.
- `src/Meziantou.Moneiz` (Blazor WASM) could not be built locally: `NETSDK1147` — the `wasm-tools` workload is not installed in that environment. This is pre-existing and unrelated to the change; CI covers it.