### PR TITLE
Remove scheduled transactions when deleting an account

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.Account.cs
+++ b/src/Meziantou.Moneiz.Core/Database.Account.cs
@@ -113,6 +113,11 @@ public partial class Database
         {
             if (Accounts.Remove(account))
             {
+                foreach (var scheduledTransaction in ScheduledTransactions.Where(t => t.Account == account || t.CreditedAccount == account).ToList())
+                {
+                    RemoveScheduledTransaction(scheduledTransaction);
+                }
+
                 foreach (var transaction in Transactions.Where(t => t.Account == account).ToList())
                 {
                     RemoveTransaction(transaction);

--- a/src/Meziantou.Moneiz.Core/Database.cs
+++ b/src/Meziantou.Moneiz.Core/Database.cs
@@ -158,6 +158,21 @@ public sealed partial class Database
                     throw new MoneizException($"Database is not valid: linked transaction of transaction '{transaction.Id}' is not valid");
             }
         }
+
+        foreach (var scheduledTransaction in ScheduledTransactions)
+        {
+            if (scheduledTransaction.Account is not null)
+            {
+                if (!Accounts.Any(a => ReferenceEquals(a, scheduledTransaction.Account)))
+                    throw new MoneizException($"Database is not valid: account of scheduled transaction '{scheduledTransaction.Id}' is not valid");
+            }
+
+            if (scheduledTransaction.CreditedAccount is not null)
+            {
+                if (!Accounts.Any(a => ReferenceEquals(a, scheduledTransaction.CreditedAccount)))
+                    throw new MoneizException($"Database is not valid: credited account of scheduled transaction '{scheduledTransaction.Id}' is not valid");
+            }
+        }
     }
 
     private static void AddOrReplace<T>(IList<T> items, T? existingItem, T newItem) where T : class

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -345,4 +345,78 @@ public class DatabaseTests
 
         Assert.Equal((IEnumerable<string>)["alpha", "beta", "gamma"], labels);
     }
+
+    [Fact]
+    public void RemoveAccount_RemovesScheduledTransactionsOfTheAccount()
+    {
+        var db = new Database();
+        var account = new Account { Name = "a1" };
+        db.SaveAccount(account);
+
+        db.SaveScheduledTransaction(new ScheduledTransaction
+        {
+            Account = account,
+            Amount = 1,
+            RecurrenceRuleText = "FREQ=daily",
+            Name = "test",
+            StartDate = Database.GetToday(),
+        });
+
+        db.RemoveAccount(account);
+
+        Assert.Empty(db.ScheduledTransactions);
+        Assert.Empty(db.Transactions);
+    }
+
+    [Fact]
+    public void RemoveAccount_RemovesScheduledTransactionsCreditingTheAccount()
+    {
+        var db = new Database();
+        var debitedAccount = new Account { Name = "a1" };
+        var creditedAccount = new Account { Name = "a2" };
+        db.SaveAccount(debitedAccount);
+        db.SaveAccount(creditedAccount);
+
+        db.SaveScheduledTransaction(new ScheduledTransaction
+        {
+            Account = debitedAccount,
+            CreditedAccount = creditedAccount,
+            Amount = 1,
+            RecurrenceRuleText = "FREQ=daily",
+            Name = "test",
+            StartDate = Database.GetToday(),
+        });
+
+        db.RemoveAccount(creditedAccount);
+
+        Assert.Empty(db.ScheduledTransactions);
+    }
+
+    [Fact]
+    public async Task RemoveAccount_ScheduledTransactionsAreNotReattachedToANewAccountAfterReload()
+    {
+        var db = new Database();
+        var account = new Account { Name = "a1" };
+        db.SaveAccount(account);
+
+        db.SaveScheduledTransaction(new ScheduledTransaction
+        {
+            Account = account,
+            Amount = 1,
+            RecurrenceRuleText = "FREQ=daily",
+            Name = "test",
+            StartDate = Database.GetToday(),
+        });
+
+        db.RemoveAccount(account);
+
+        var newAccount = new Account { Name = "a2" };
+        db.SaveAccount(newAccount);
+        Assert.Equal(account.Id, newAccount.Id);
+
+        var imported = await Database.Load(db.Export());
+
+        Assert.Empty(imported.ScheduledTransactions);
+        Assert.Empty(imported.Transactions);
+    }
 }


### PR DESCRIPTION
## What

`Database.RemoveAccount` removed the account's transactions but ignored scheduled transactions that reference the account through `Account` or `CreditedAccount`. Those schedules kept a live reference to the removed account object, so `ScheduledTransaction.AccountId` still serialized the deleted account's id.

Account ids get reused — `GenerateId` returns `max + 1` over the remaining accounts — so deleting an account that owns a schedule, creating a replacement account, then exporting and reloading silently attached the original schedule to the *replacement* account, which then generated transactions on the wrong account.

## Changes

- `RemoveAccount` now removes every scheduled transaction that references the deleted account on either side, inside the existing `DeferEvents` scope.
- `AssertNoDetachedReferences` validates `Account` and `CreditedAccount` on scheduled transactions when loading a database, following the same `ReferenceEquals` pattern already used for transactions.
- Three tests in `DatabaseTests`: deletion drops schedules on the debited account, on the credited account, and the full reproduction (delete → recreate account with the reused id → export/reload).

## Why removal rather than reassignment

The debited account is mandatory on a schedule — the edit form always sets it — so a schedule cannot survive without one. For the credited side, clearing only `CreditedAccount` would silently turn a transfer into a plain transaction *and* flip its sign, since `ProcessScheduledTransaction` uses `-Math.Abs(Amount)` for transfers and the raw `Amount` otherwise. Removing the schedule is the predictable outcome in both cases.

## Verification

- `Meziantou.Moneiz.Core` and the test project build with 0 warnings.
- Full core suite: 24/24 passing.
- With the `RemoveAccount` change reverted, all three new tests fail (the reload test shows the schedule surviving into the imported database); they pass with it restored.

Note: `dotnet build` on the whole solution fails locally with `NETSDK1147: workloads must be installed: wasm-tools` for the Blazor WASM app. That is an environment limitation on my machine — the failure happens before any compilation and no file in that project was touched. CI should cover it.