### PR TITLE
fix: allow creating an account when all existing accounts are closed

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.Account.cs
+++ b/src/Meziantou.Moneiz.Core/Database.Account.cs
@@ -21,9 +21,10 @@ public partial class Database
         if (existingAccount is null)
         {
             account.Id = GenerateId(Accounts, a => a.Id);
-            if (Accounts.Count > 0)
+            var maxSortOrder = Accounts.Where(a => !a.Closed).Max(a => (int?)a.SortOrder);
+            if (maxSortOrder is not null)
             {
-                account.SortOrder = Accounts.Where(account => !account.Closed).Max(account => account.SortOrder) + 1;
+                account.SortOrder = maxSortOrder.GetValueOrDefault() + 1;
             }
         }
 

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -181,6 +181,21 @@ public class DatabaseTests
     }
 
     [Fact]
+    public void SaveAccountWhenAllExistingAccountsAreClosed()
+    {
+        var database = new Database();
+        var closedAccount = new Account { Name = "Closed account", Closed = true };
+        database.SaveAccount(closedAccount);
+
+        var newAccount = new Account { Name = "New account" };
+        database.SaveAccount(newAccount);
+
+        Assert.HasCount(2, database.Accounts);
+        Assert.Equal([newAccount], database.VisibleAccounts);
+        Assert.Equal(0, newAccount.SortOrder);
+    }
+
+    [Fact]
     public void MoveAccountBeforeReordersAccounts()
     {
         var database = new Database();


### PR DESCRIPTION
## What

`Database.SaveAccount` threw `InvalidOperationException: Sequence contains no elements` when creating a new account in a database where every existing account is closed, so the account could not be created.

The guard checked `Accounts.Count > 0`, but the `Max` ran over `Accounts.Where(a => !a.Closed)`. With at least one account and all of them closed, that filtered sequence is empty and `Max` throws.

## How

Compute the maximum over `int?`, which yields `null` for an empty sequence instead of throwing, and only bump `SortOrder` when a value exists. This also drops the now-redundant `Accounts.Count` check and removes the lambda parameter that shadowed `account`.

```csharp
var maxSortOrder = Accounts.Where(a => !a.Closed).Max(a => (int?)a.SortOrder);
if (maxSortOrder is not null)
{
    account.SortOrder = maxSortOrder.GetValueOrDefault() + 1;
}
```

Behavior is unchanged when open accounts exist. When none do, the new account keeps its default `SortOrder` — the same path already taken for the very first account of an empty database.

## Testing

Added `SaveAccountWhenAllExistingAccountsAreClosed` to `DatabaseTests`, reproducing the exact scenario. It fails on the previous code with `InvalidOperationException` and passes with the fix (verified both ways). All 22 tests in `Meziantou.Moneiz.CoreTests` pass and `Meziantou.Moneiz.Core` builds clean.

Note for the reviewer: the Blazor project `src/Meziantou.Moneiz` was not compiled locally because the `wasm-tools` workload is not installed on this machine (`NETSDK1147`). That is a pre-existing environment limitation, unrelated to this change, which touches only `Meziantou.Moneiz.Core` and its tests. CI covers it.