### PR TITLE
fix: include upcoming scheduled payments in overdraft forecasts

### DIFF
--- a/src/Meziantou.Moneiz.Cli/Program.cs
+++ b/src/Meziantou.Moneiz.Cli/Program.cs
@@ -292,11 +292,7 @@ static async Task CheckOverdraftAsync(FileInfo file, string? accountIdFilter)
         var minimumBalance = account.OverdraftNotificationAmount;
         var targetDate = today.AddDays(days);
 
-        // Process scheduled transactions up to the target date for this account
-        var tempDb = db;
-        tempDb.ProcessScheduledTransactions(days);
-
-        var currentBalance = tempDb.GetTodayBalance(account);
+        var currentBalance = db.GetProjectedBalance(account, today);
 
         // Check balance for each day in the period
         DateOnly? overdraftDate = null;
@@ -305,7 +301,7 @@ static async Task CheckOverdraftAsync(FileInfo file, string? accountIdFilter)
         for (var i = 0; i <= days; i++)
         {
             var checkDate = today.AddDays(i);
-            var balance = tempDb.GetBalance(account, checkDate);
+            var balance = db.GetProjectedBalance(account, checkDate);
 
             if (balance < minimumBalance)
             {
@@ -346,7 +342,7 @@ static async Task CheckOverdraftAsync(FileInfo file, string? accountIdFilter)
         }
         else
         {
-            var projectedBalance = tempDb.GetBalance(account, targetDate);
+            var projectedBalance = db.GetProjectedBalance(account, targetDate);
             Console.WriteLine($"  Projected balance ({targetDate:yyyy-MM-dd}): {FormatAmount(projectedBalance, account.CurrencyIsoCode)}");
         }
 

--- a/src/Meziantou.Moneiz.Core/Database.Account.cs
+++ b/src/Meziantou.Moneiz.Core/Database.Account.cs
@@ -154,6 +154,15 @@ public partial class Database
         return GetBalance(account, DateOnly.MaxValue, TransactionState.NotChecked);
     }
 
+    /// <summary>
+    /// Gets the balance of the account at the given date, including the scheduled transactions
+    /// that are not materialized yet. The database is not modified.
+    /// </summary>
+    public decimal GetProjectedBalance(Account account, DateOnly date)
+    {
+        return GetBalance(account, date) + GetPendingScheduledTransactionsAmount(account, date);
+    }
+
     private decimal GetBalance(Account account, DateOnly date, TransactionState transactionState)
     {
         return account.InitialBalance + Transactions.Where(IncludeTransaction).Sum(t => t.Amount);

--- a/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
+++ b/src/Meziantou.Moneiz.Core/Database.ScheduledTransaction.cs
@@ -56,6 +56,64 @@ public partial class Database
         }
     }
 
+    /// <summary>
+    /// Computes the total amount of the scheduled transaction occurrences that impact the account
+    /// up to <paramref name="date"/> and that are not materialized yet.
+    /// </summary>
+    private decimal GetPendingScheduledTransactionsAmount(Account account, DateOnly date)
+    {
+        var total = 0m;
+        foreach (var scheduledTransaction in ScheduledTransactions)
+        {
+            var amount = GetOccurrenceAmount(scheduledTransaction, account);
+            if (amount == 0)
+                continue;
+
+            total += amount * GetPendingOccurrences(scheduledTransaction, date).Count();
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Gets the amount a single occurrence of the scheduled transaction adds to the account balance.
+    /// </summary>
+    private static decimal GetOccurrenceAmount(ScheduledTransaction scheduledTransaction, Account account)
+    {
+        var interAccount = scheduledTransaction.CreditedAccount is not null;
+
+        var amount = 0m;
+        if (scheduledTransaction.Account == account)
+        {
+            amount += interAccount ? -Math.Abs(scheduledTransaction.Amount) : scheduledTransaction.Amount;
+        }
+
+        if (interAccount && scheduledTransaction.CreditedAccount == account)
+        {
+            amount += Math.Abs(scheduledTransaction.Amount);
+        }
+
+        return amount;
+    }
+
+    private static IEnumerable<DateOnly> GetPendingOccurrences(ScheduledTransaction scheduledTransaction, DateOnly maxDate)
+    {
+        DateOnly? previousOccurrence = null;
+        foreach (var occurrence in scheduledTransaction.GetNextOccurences())
+        {
+            var occurrenceDate = DateOnly.FromDateTime(occurrence);
+            if (occurrenceDate > maxDate)
+                yield break;
+
+            // The recurrence rule must move forward, otherwise the enumeration never ends
+            if (previousOccurrence >= occurrenceDate)
+                yield break;
+
+            previousOccurrence = occurrenceDate;
+            yield return occurrenceDate;
+        }
+    }
+
     public void ProcessScheduledTransactions(int daysAhead)
     {
         using (DeferEvents())

--- a/src/Meziantou.Moneiz/Shared/OverdraftWarning.razor
+++ b/src/Meziantou.Moneiz/Shared/OverdraftWarning.razor
@@ -107,7 +107,7 @@
                 for (var i = 0; i <= days; i++)
                 {
                     var checkDate = today.AddDays(i);
-                    var balance = db.GetBalance(account, checkDate);
+                    var balance = db.GetProjectedBalance(account, checkDate);
 
                     if (balance < minimumBalance)
                     {

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -345,4 +345,87 @@ public class DatabaseTests
 
         Assert.Equal((IEnumerable<string>)["alpha", "beta", "gamma"], labels);
     }
+
+    [Fact]
+    public void GetProjectedBalance_IncludesScheduledTransactionsBeyondTheMaterializedWindow()
+    {
+        var db = new Database();
+        var account = new Account { InitialBalance = 100 };
+        db.SaveAccount(account);
+
+        var scheduledTransaction = new ScheduledTransaction
+        {
+            Account = account,
+            Amount = -200,
+            RecurrenceRuleText = "FREQ=MONTHLY;BYMONTHDAY=10",
+            Name = "test",
+            StartDate = new DateOnly(2026, 08, 10),
+            NextOccurenceDate = new DateOnly(2026, 08, 10),
+        };
+
+        db.SaveScheduledTransaction(scheduledTransaction);
+
+        Assert.Empty(db.Transactions);
+        Assert.Equal(100, db.GetBalance(account, new DateOnly(2026, 09, 10)));
+
+        Assert.Equal(100, db.GetProjectedBalance(account, new DateOnly(2026, 08, 09)));
+        Assert.Equal(-100, db.GetProjectedBalance(account, new DateOnly(2026, 08, 10)));
+        Assert.Equal(-300, db.GetProjectedBalance(account, new DateOnly(2026, 09, 10)));
+
+        // The projection must not materialize anything
+        Assert.Empty(db.Transactions);
+        Assert.Equal(new DateOnly(2026, 08, 10), scheduledTransaction.NextOccurenceDate);
+    }
+
+    [Fact]
+    public void GetProjectedBalance_DoesNotCountMaterializedOccurrencesTwice()
+    {
+        var today = Database.GetToday();
+        var db = new Database();
+        var account = new Account();
+        db.SaveAccount(account);
+
+        db.SaveScheduledTransaction(new ScheduledTransaction
+        {
+            Account = account,
+            Amount = -1,
+            RecurrenceRuleText = "FREQ=DAILY",
+            Name = "test",
+            StartDate = today,
+        });
+
+        Assert.HasCount(5, db.Transactions);
+        Assert.Equal(-5, db.GetBalance(account, today.AddDays(9)));
+
+        Assert.Equal(-5, db.GetProjectedBalance(account, today.AddDays(4)));
+        Assert.Equal(-10, db.GetProjectedBalance(account, today.AddDays(9)));
+    }
+
+    [Fact]
+    public void GetProjectedBalance_HandlesInterAccountScheduledTransactions()
+    {
+        var db = new Database();
+        var debitedAccount = new Account { Name = "debited", InitialBalance = 100 };
+        var creditedAccount = new Account { Name = "credited" };
+        var otherAccount = new Account { Name = "other" };
+        db.SaveAccount(debitedAccount);
+        db.SaveAccount(creditedAccount);
+        db.SaveAccount(otherAccount);
+
+        db.SaveScheduledTransaction(new ScheduledTransaction
+        {
+            Account = debitedAccount,
+            CreditedAccount = creditedAccount,
+            Amount = 30,
+            RecurrenceRuleText = "FREQ=MONTHLY;BYMONTHDAY=10",
+            Name = "test",
+            StartDate = new DateOnly(2026, 08, 10),
+            NextOccurenceDate = new DateOnly(2026, 08, 10),
+        });
+
+        Assert.Equal(100, db.GetProjectedBalance(debitedAccount, new DateOnly(2026, 08, 09)));
+        Assert.Equal(70, db.GetProjectedBalance(debitedAccount, new DateOnly(2026, 08, 10)));
+        Assert.Equal(30, db.GetProjectedBalance(creditedAccount, new DateOnly(2026, 08, 10)));
+        Assert.Equal(0, db.GetProjectedBalance(otherAccount, new DateOnly(2026, 09, 10)));
+    }
 }


### PR DESCRIPTION
## Problem

The overdraft warning scanned only materialized transactions. Normal schedule processing generates roughly five days ahead (`ProcessScheduledTransactions()` defaults to 5), while an account can configure a much longer `OverdraftNotificationCheckPeriodDays`. Any scheduled payment past that materialized window was therefore absent from the forecast.

Repro: an account with an initial balance of 100, a 30-day warning period, and a scheduled debit of 200 on day 10 kept reporting +100. Materializing the schedule through the requested horizon yields -100 on day 10.

## What changed

**`Database.GetProjectedBalance(account, date)`** (`Database.Account.cs`) — the materialized balance at `date` plus the scheduled occurrences up to `date` that have not been generated yet. It is a pure read: nothing is materialized and `NextOccurenceDate` is not advanced.

Supporting private helpers in `Database.ScheduledTransaction.cs`:

- `GetPendingScheduledTransactionsAmount` sums, per scheduled transaction, the per-occurrence amount × the number of pending occurrences within the horizon.
- `GetOccurrenceAmount` mirrors the sign rules used when materializing: a transfer debits `Account` by `-Abs(Amount)` and credits `CreditedAccount` by `+Abs(Amount)`; a plain transaction uses `Amount` as-is.
- `GetPendingOccurrences` walks `ScheduledTransaction.GetNextOccurences()` and stops past the horizon.

**Call sites:** `OverdraftWarning.razor` and the CLI `check-overdraft` command now use the projection.

## Notes for the reviewer

- **No double counting.** `GetNextOccurences()` starts at `NextOccurenceDate`, which by construction is the first *not yet materialized* occurrence, so the pending tail and the materialized transactions are disjoint. `GetProjectedBalance_DoesNotCountMaterializedOccurrencesTwice` pins this.
- **Occurrences in the past are included.** If a schedule was never processed, `NextOccurenceDate` can be earlier than today; such an occurrence is `<= date` and legitimately counts toward the projected balance.
- **`GetPendingOccurrences` bails out if the recurrence rule fails to move forward.** That enumeration is otherwise infinite for a stuck rule; `ProcessScheduledTransaction` already guards against the same case.
- **The CLI change is slightly wider than the reported issue.** `check-overdraft` covered the gap by calling `ProcessScheduledTransactions(days)` on the live in-memory database, inside a per-account loop — so later accounts saw state accumulated from earlier ones. Since computing a projection should not mutate the database, that call is gone and the command uses `GetProjectedBalance` throughout. Results are unchanged apart from the removed order dependence; the database is never written back to disk by this command either way.

## Tests

Three tests added to `DatabaseTests.cs`: the reported repro (including an assertion that the database is unchanged afterwards), the no-double-counting case against the ~5-day materialized window, and inter-account transfer signs.

Full suite: 24/24 passing (21 before). Core, CLI, and Blazor projects build.

Caveat on local verification: the Blazor project needs the `wasm-tools` workload, which is not installed on this machine and requires elevated privileges to install. I built it with `-p:MSBuildEnableWorkloadResolver=false`, which compiles all C#/Razor — so the `OverdraftWarning.razor` change is verified — but skips the wasm AOT/link step. CI covers that.