### PR TITLE
Add the missing check-overdraft subcommand to the overdraft workflow

### DIFF
--- a/.github/workflows/check-overdraft.yml
+++ b/.github/workflows/check-overdraft.yml
@@ -37,8 +37,8 @@ jobs:
         shell: pwsh
         run: |
           if ([string]::IsNullOrEmpty("${{ inputs.account-ids }}")) {
-            meziantou.moneiz --file "${{ inputs.database-path }}"
+            meziantou.moneiz check-overdraft --file "${{ inputs.database-path }}"
           } else {
-            meziantou.moneiz --file "${{ inputs.database-path }}" --account-id "${{ inputs.account-ids }}"
+            meziantou.moneiz check-overdraft --file "${{ inputs.database-path }}" --account-id "${{ inputs.account-ids }}"
           }
 


### PR DESCRIPTION
## What changed

`.github/workflows/check-overdraft.yml` now invokes the `check-overdraft` subcommand in both branches of the PowerShell step:

```diff
-  meziantou.moneiz --file "${{ inputs.database-path }}"
+  meziantou.moneiz check-overdraft --file "${{ inputs.database-path }}"
-  meziantou.moneiz --file "${{ inputs.database-path }}" --account-id "${{ inputs.account-ids }}"
+  meziantou.moneiz check-overdraft --file "${{ inputs.database-path }}" --account-id "${{ inputs.account-ids }}"
```

## Why

The reusable workflow called the tool with no subcommand. The CLI's root command has no action of its own — `--file` and `--account-id` are defined on the `check-overdraft` subcommand — so System.CommandLine rejected the invocation before any work happened. Running the old shape against the built CLI:

```
'--file' was not matched. Did you mean one of the following?
Required command was not provided.
Unrecognized command or argument '--file'.
```

Exit code 1, help text printed, no balances checked. Because the step exits non-zero, the job failed rather than silently passing — but it failed for the wrong reason and never actually verified an account.

## Verification

Built `Meziantou.Moneiz.Cli` and ran both shapes against a nonexistent database path:

- Old shape: parser error above, exit 1.
- New shape, with and without `--account-id "1,2,3"`: `Error: Database file '...' not found.`, exit 1 — parsing succeeds and execution reaches `CheckOverdraftAsync`, failing only on the intentionally missing file.

The workflow YAML still parses. `Meziantou.Moneiz.Cli` and `Meziantou.Moneiz.Core` build clean; `Meziantou.Moneiz.CoreTests` passes 21/21 (run via the test executable directly — `dotnet test` reports "Zero tests ran" in this environment, unrelated to this change). `src/Meziantou.Moneiz` could not be built locally because the `wasm-tools` workload isn't installed here; it is untouched by this change.

## Note for the reviewer

Not addressed here, but adjacent: the workflow's `account-ids` input is documented as "space or comma-separated (e.g. `1 2 3` or `1,2,3`)", while `Program.cs` splits only on `,`. A space-separated value becomes one unparseable token, so the CLI warns and then exits 1 with "Account ID(s) not found". Either the input description or the split should change — happy to follow up whichever way you prefer.