### PR TITLE
Fix database change events being lost after an import

### DIFF
--- a/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
+++ b/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
@@ -74,9 +74,10 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
                         }
 
                         _database ??= new Database();
-                    }
 
-                    _database.DatabaseChanged += Database_DatabaseChanged;
+                        // When the database comes from GitHub, Import has already subscribed to the new instance
+                        _database.DatabaseChanged += Database_DatabaseChanged;
+                    }
                 }
             }
             finally
@@ -135,6 +136,7 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
         }
 
         _database = database;
+        _database.DatabaseChanged += Database_DatabaseChanged;
         RaiseDatabaseChanged();
     }
 

--- a/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
+++ b/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
@@ -68,15 +68,7 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
                     if (_database is null)
                     {
                         var result = await GlobalInterop.GetByteArrayValue(MoneizLocalStorageDbName);
-                        if (result is not null)
-                        {
-                            _database = await Database.Load(result);
-                        }
-
-                        _database ??= new Database();
-
-                        // When the database comes from GitHub, Import has already subscribed to the new instance
-                        _database.DatabaseChanged += Database_DatabaseChanged;
+                        SetDatabase(result is not null ? await Database.Load(result) : new Database());
                     }
                 }
             }
@@ -130,14 +122,28 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
     public async Task Import(Database database)
     {
         await Save(database, new SaveOptions { IndicateDbChanged = false });
-        if (_database is not null)
+        SetDatabase(database);
+        RaiseDatabaseChanged();
+    }
+
+    /// <summary>
+    /// Makes <paramref name="database"/> the current database, moving the <see cref="Database.DatabaseChanged"/>
+    /// subscription off the previous instance so changes are forwarded exactly once.
+    /// </summary>
+    [MemberNotNull(nameof(_database))]
+    private void SetDatabase(Database database)
+    {
+        if (!ReferenceEquals(_database, database))
         {
-            _database.DatabaseChanged -= Database_DatabaseChanged;
+            if (_database is not null)
+            {
+                _database.DatabaseChanged -= Database_DatabaseChanged;
+            }
+
+            database.DatabaseChanged += Database_DatabaseChanged;
         }
 
         _database = database;
-        _database.DatabaseChanged += Database_DatabaseChanged;
-        RaiseDatabaseChanged();
     }
 
     private void Database_DatabaseChanged(object? sender, EventArgs e) => RaiseDatabaseChanged();


### PR DESCRIPTION
## What changed

`DatabaseProvider.Import` unsubscribed `Database_DatabaseChanged` from the outgoing database and swapped in the replacement, but never subscribed to the new instance. The only subscription lived in `GetDatabase`, on the initial-load path.

Two coordinated edits, so every `Database` instance ends up with exactly one subscription:

- `Import` now subscribes to the replacement instance right after the swap, before raising the notification.
- `GetDatabase` moves its `+=` *inside* the `if (_database is null)` block that builds the instance from local storage.

## Why

After any manual import, edits to the new `Database` no longer propagated to `DatabaseProvider.DatabaseChanged`. Sidebar balances in `NavMenu.razor` stayed stale and `OverdraftWarning.razor` lost its immediate event-driven updates, until something else happened to trigger a re-render. Explicit saves still persisted the edits, so the data was never at risk — only the UI went quiet.

## Note for reviewers

The second edit is the non-obvious half, and it is what keeps this from trading one bug for another. On startup, `GetDatabase` can reach the database via `ImportFromGitHub(implicitLoad: true)` → `Import`, which now subscribes on its own. The previously unconditional `+=` that followed would then have fired a second time on that same instance, and every subsequent edit would have raised `DatabaseChanged` twice. Scoping it to the branch that actually constructs the instance keeps both paths at one subscription each.

## Testing

- `dotnet test tests/Meziantou.Moneiz.CoreTests`: 21 passed, 0 failed.
- Building the whole solution fails in my environment for a pre-existing, unrelated reason: the `wasm-tools` workload is not installed and `dotnet workload install` requires elevated privileges. I worked around it with `-p:MSBuildEnableWorkloadResolver=false`, which builds `Meziantou.Moneiz.csproj` — the project holding this change — cleanly with 0 warnings and 0 errors. That compiles the C# but skips the WASM/AOT native steps, which this change does not touch. CI should be treated as the real signal for the full build.

No test covers this change. The only test project references `Meziantou.Moneiz.Core`, while `DatabaseProvider` lives in the Blazor WASM project and its `Save` path depends on `GlobalInterop` JS interop, so it is not reachable from the current test setup without introducing a storage abstraction and a new test project. The behavior here was verified by tracing both call paths rather than by execution.
