### PR TITLE
Fix inline transfer edit updating the wrong transaction

### DIFF
--- a/src/Meziantou.Moneiz.Core/TransactionEdit.cs
+++ b/src/Meziantou.Moneiz.Core/TransactionEdit.cs
@@ -53,7 +53,10 @@ public sealed class TransactionEdit
         {
             Debug.Assert(DebitedAccount is not null);
 
-            var transaction = database.GetDebitedTransactionById(Id);
+            // When editing the current transaction, the edit model describes the selected transaction itself
+            // (its own account and signed amount), so it must be resolved by its exact id. Other flows build
+            // the model around the debited side, so they normalize to it.
+            var transaction = _editCurrentTransaction ? database.GetTransactionById(Id) : database.GetDebitedTransactionById(Id);
             if (transaction is null)
             {
                 transaction = new Transaction();

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -345,4 +345,96 @@ public class DatabaseTests
 
         Assert.Equal((IEnumerable<string>)["alpha", "beta", "gamma"], labels);
     }
+
+    [Fact]
+    public void TransactionEdit_InlineEditOfCreditedTransfer_KeepsEachSideOnItsOwnAccount()
+    {
+        var source = new Account { Id = 1, Name = "source" };
+        var destination = new Account { Id = 2, Name = "destination" };
+        var today = Database.GetToday();
+        var reconciliationDate = new DateTime(2026, 01, 02, 03, 04, 05, DateTimeKind.Utc);
+        var debited = new Transaction { Id = 1, Account = source, Amount = -100, ValueDate = today, CheckedDate = today, ReconciliationDate = reconciliationDate };
+        var credited = new Transaction { Id = 2, Account = destination, Amount = 100, ValueDate = today, LinkedTransaction = debited };
+        debited.LinkedTransaction = credited;
+
+        var db = new Database
+        {
+            Accounts = { source, destination },
+            Transactions = { debited, credited },
+        };
+
+        var edit = TransactionEdit.FromTransaction(credited, editCurrentTransaction: true);
+        edit.Comment = "updated";
+        edit.Save(db);
+
+        Assert.Same(source, db.GetTransactionById(1)!.Account);
+        Assert.Equal(-100, db.GetTransactionById(1)!.Amount);
+        Assert.Equal(reconciliationDate, db.GetTransactionById(1)!.ReconciliationDate);
+
+        Assert.Same(destination, db.GetTransactionById(2)!.Account);
+        Assert.Equal(100, db.GetTransactionById(2)!.Amount);
+        Assert.Null(db.GetTransactionById(2)!.ReconciliationDate);
+
+        Assert.Equal("updated", db.GetTransactionById(1)!.Comment);
+        Assert.Equal("updated", db.GetTransactionById(2)!.Comment);
+    }
+
+    [Fact]
+    public void TransactionEdit_InlineEditOfDebitedTransfer_KeepsEachSideOnItsOwnAccount()
+    {
+        var source = new Account { Id = 1, Name = "source" };
+        var destination = new Account { Id = 2, Name = "destination" };
+        var today = Database.GetToday();
+        var reconciliationDate = new DateTime(2026, 01, 02, 03, 04, 05, DateTimeKind.Utc);
+        var debited = new Transaction { Id = 1, Account = source, Amount = -100, ValueDate = today, CheckedDate = today, ReconciliationDate = reconciliationDate };
+        var credited = new Transaction { Id = 2, Account = destination, Amount = 100, ValueDate = today, LinkedTransaction = debited };
+        debited.LinkedTransaction = credited;
+
+        var db = new Database
+        {
+            Accounts = { source, destination },
+            Transactions = { debited, credited },
+        };
+
+        var edit = TransactionEdit.FromTransaction(debited, editCurrentTransaction: true);
+        edit.Comment = "updated";
+        edit.Save(db);
+
+        Assert.Same(source, db.GetTransactionById(1)!.Account);
+        Assert.Equal(-100, db.GetTransactionById(1)!.Amount);
+        Assert.Equal(reconciliationDate, db.GetTransactionById(1)!.ReconciliationDate);
+
+        Assert.Same(destination, db.GetTransactionById(2)!.Account);
+        Assert.Equal(100, db.GetTransactionById(2)!.Amount);
+
+        Assert.Equal("updated", db.GetTransactionById(1)!.Comment);
+        Assert.Equal("updated", db.GetTransactionById(2)!.Comment);
+    }
+
+    [Fact]
+    public void TransactionEdit_InlineEditAmountOfCreditedTransfer_UpdatesBothSides()
+    {
+        var source = new Account { Id = 1, Name = "source" };
+        var destination = new Account { Id = 2, Name = "destination" };
+        var today = Database.GetToday();
+        var debited = new Transaction { Id = 1, Account = source, Amount = -100, ValueDate = today };
+        var credited = new Transaction { Id = 2, Account = destination, Amount = 100, ValueDate = today, LinkedTransaction = debited };
+        debited.LinkedTransaction = credited;
+
+        var db = new Database
+        {
+            Accounts = { source, destination },
+            Transactions = { debited, credited },
+        };
+
+        var edit = TransactionEdit.FromTransaction(credited, editCurrentTransaction: true);
+        edit.Amount = 150;
+        edit.Save(db);
+
+        Assert.Same(source, db.GetTransactionById(1)!.Account);
+        Assert.Equal(-150, db.GetTransactionById(1)!.Amount);
+
+        Assert.Same(destination, db.GetTransactionById(2)!.Account);
+        Assert.Equal(150, db.GetTransactionById(2)!.Amount);
+    }
 }


### PR DESCRIPTION
## What

`TransactionEdit.Save` always resolved the transaction with `GetDebitedTransactionById`, even when the edit model was built from the credited side of a transfer via `editCurrentTransaction`. It now resolves the exact transaction id for that case, and keeps normalizing to the debited side for the flows whose edit model is built around it.

## Why

`FromTransaction` captures the selected row's own account and signed amount when `editCurrentTransaction` is set — that is the inline-edit path in `Pages/Transactions/Index.razor`. Resolving via `GetDebitedTransactionById` then hopped to the linked transaction, so the credited row's account and positive amount were applied to the debited object and the mirrored values to the other one.

The result: the two transaction IDs swapped accounts and signs, while `CheckedDate` and `ReconciliationDate` stayed attached to the original objects. Reconciling the debit of a `Source -> Destination` transfer and then inline-editing the destination credit's comment moved the reconciliation onto the wrong account.

## Testing

Three tests added to `DatabaseTests.cs`, covering inline edit of the credited side, of the debited side, and an amount change made from the credited side.

Reverting the one-line fix makes the two credited-side tests fail with exactly the reported symptom (`Expected: same instance as source / Actual: destination`); with the fix, all 24 tests pass.

## Notes for the reviewer

- `Meziantou.Moneiz.Core`, `Meziantou.Moneiz.Cli` and the test project build clean. The `Meziantou.Moneiz` Blazor WASM project could not be built locally — it fails at `NETSDK1147` for the missing `wasm-tools` workload, before compilation. That is unrelated to this change, which touches only Core and tests.
- `dotnet test` reports "Zero tests ran" in this repo, so the tests were run through the test binary directly.
- Related but **not** fixed here, since it is a different symptom: quick-duplicating the credited side of a transfer produces a copy running in the opposite direction. `FromTransaction` has the same account/side assumption, and for a duplicate `Id` is null so there is no existing transaction to normalize against. Worth a follow-up.
