### PR TITLE
Keep the transfer direction when duplicating the credited side

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.Transaction.cs
+++ b/src/Meziantou.Moneiz.Core/Database.Transaction.cs
@@ -15,14 +15,7 @@ public partial class Database
         if (id is null)
             return null;
 
-        var transaction = Transactions.FirstOrDefault(item => item.Id == id);
-        if (transaction is null)
-            return null;
-
-        if (transaction.Amount > 0 && transaction.LinkedTransaction is not null)
-            return transaction.LinkedTransaction;
-
-        return transaction;
+        return Transactions.FirstOrDefault(item => item.Id == id)?.DebitedTransaction;
     }
 
     public void SaveTransaction(Transaction transaction)

--- a/src/Meziantou.Moneiz.Core/Transaction.cs
+++ b/src/Meziantou.Moneiz.Core/Transaction.cs
@@ -107,6 +107,12 @@ public sealed class Transaction
     [JsonIgnore]
     public string? FinalTitle => Payee?.ToString() ?? LinkedTransaction?.Account?.ToString();
 
+    /// <summary>
+    /// Gets the debited side of the transfer this transaction belongs to, or the transaction itself when it is not part of a transfer.
+    /// </summary>
+    [JsonIgnore]
+    public Transaction DebitedTransaction => Amount > 0 && LinkedTransaction is not null ? LinkedTransaction : this;
+
     [JsonIgnore]
     public TransactionState State
     {

--- a/src/Meziantou.Moneiz.Core/TransactionEdit.cs
+++ b/src/Meziantou.Moneiz.Core/TransactionEdit.cs
@@ -20,6 +20,12 @@ public sealed class TransactionEdit
 
     public static TransactionEdit FromTransaction(Transaction transaction, bool createNewTransaction = false, bool editCurrentTransaction = false)
     {
+        if (createNewTransaction)
+        {
+            // Duplicate the debited side so the copy keeps the direction of the original transfer
+            transaction = transaction.DebitedTransaction;
+        }
+
         return new TransactionEdit
         {
             Id = createNewTransaction ? null : transaction.Id,

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -328,6 +328,52 @@ public class DatabaseTests
     }
 
     [Fact]
+    public void DuplicateTransfer_FromCreditedTransaction_KeepsTheDirection()
+    {
+        var source = new Account { Id = 1, Name = "Source" };
+        var destination = new Account { Id = 2, Name = "Destination" };
+        var debitedTransaction = new Transaction { Id = 1, Account = source, Amount = -100, ValueDate = new DateOnly(2026, 01, 01) };
+        var creditedTransaction = new Transaction { Id = 2, Account = destination, Amount = 100, ValueDate = new DateOnly(2026, 01, 01), LinkedTransaction = debitedTransaction };
+        debitedTransaction.LinkedTransaction = creditedTransaction;
+
+        var db = new Database
+        {
+            Accounts = { source, destination },
+            Transactions = { debitedTransaction, creditedTransaction },
+        };
+
+        var duplicate = TransactionEdit.FromTransaction(creditedTransaction, createNewTransaction: true);
+        duplicate.Save(db);
+
+        Assert.HasCount(4, db.Transactions);
+        Assert.Equal(-200, db.GetBalance(source));
+        Assert.Equal(200, db.GetBalance(destination));
+    }
+
+    [Fact]
+    public void DuplicateTransfer_FromDebitedTransaction_KeepsTheDirection()
+    {
+        var source = new Account { Id = 1, Name = "Source" };
+        var destination = new Account { Id = 2, Name = "Destination" };
+        var debitedTransaction = new Transaction { Id = 1, Account = source, Amount = -100, ValueDate = new DateOnly(2026, 01, 01) };
+        var creditedTransaction = new Transaction { Id = 2, Account = destination, Amount = 100, ValueDate = new DateOnly(2026, 01, 01), LinkedTransaction = debitedTransaction };
+        debitedTransaction.LinkedTransaction = creditedTransaction;
+
+        var db = new Database
+        {
+            Accounts = { source, destination },
+            Transactions = { debitedTransaction, creditedTransaction },
+        };
+
+        var duplicate = TransactionEdit.FromTransaction(debitedTransaction, createNewTransaction: true);
+        duplicate.Save(db);
+
+        Assert.HasCount(4, db.Transactions);
+        Assert.Equal(-200, db.GetBalance(source));
+        Assert.Equal(200, db.GetBalance(destination));
+    }
+
+    [Fact]
     public void GetAllLabels_ReturnsDistinctSortedLabels()
     {
         var account = new Account { Id = 1 };


### PR DESCRIPTION
## What

Duplicating a transfer from its **credited** (positive) row reversed the transfer's direction.

`TransactionEdit.FromTransaction` treated the selected row's account as the debited account, and `Save` then negated the amount for that account. Starting from a transfer of 100 from Source to Destination and duplicating the credited row produced a transfer of 100 *back* from Destination to Source — returning both balances to zero instead of leaving -200 and +200.

## Why

`FromTransaction` now normalizes to the debited side of a transfer when `createNewTransaction` is set. Both duplication entry points funnel through that flag, so a single guard covers both:

- `QuickDuplicate` in `Pages/Transactions/Index.razor`, which passes the selected row straight through;
- the edit form in `Pages/Transactions/Edit.razor`, which resolves the `duplicatedTransaction` query string with `GetTransactionById` (unlike the edit path, which already normalized via `GetDebitedTransactionById`).

Inline editing (`editCurrentTransaction: true`) is deliberately left alone — it operates on the row as displayed.

The `Amount > 0 && LinkedTransaction is not null` check is extracted into a new `Transaction.DebitedTransaction` property, since `Database.GetDebitedTransactionById` already contained the same logic; that method now delegates to the property instead of duplicating it.

## Notes for reviewers

- Two tests added to `DatabaseTests`, covering duplication from each side of a transfer. The credited-side test was confirmed to catch the bug: with the fix reverted it fails with the exact reported symptom (`GetBalance(source)` is `0` instead of `-200`).
- Full test suite passes (23/23). `Meziantou.Moneiz.Core`, `Meziantou.Moneiz.Cli` and the test project build with 0 warnings.
- The Blazor project `src/Meziantou.Moneiz` could **not** be built locally — it fails with `NETSDK1147: the following workloads must be installed: wasm-tools`, a pre-existing environment gap unrelated to this change. No compile-time impact is possible from this diff: no signature changed, and `DebitedTransaction` is purely additive. CI will cover it.

## Adjacent issue (not addressed here)

While tracing this, `BeginInlineEdit` (`Pages/Transactions/Index.razor`) looks like it has a related problem: it passes a credited row straight through, so `DebitedAccount` receives the credited account and `CreditedAccount` the debited one, while `Save` resolves the row to the debited transaction via `GetDebitedTransactionById`. That would swap the two accounts when inline-editing the positive side of a transfer. Left out of scope for this PR.