### PR TITLE
Do not mark the database as synchronized when it changed during an export

### DIFF
--- a/src/Meziantou.Moneiz.Core/Database.cs
+++ b/src/Meziantou.Moneiz.Core/Database.cs
@@ -46,6 +46,12 @@ public sealed partial class Database
     [JsonPropertyName("g")]
     public DateTime LastModifiedDate { get; set; } = DateTime.UtcNow;
 
+    /// <summary>
+    /// Incremented every time the database is modified. It allows to detect the modifications made while an export was running.
+    /// </summary>
+    [JsonIgnore]
+    public int Revision { get; private set; }
+
     public byte[] Export()
     {
         using var ms = new MemoryStream();
@@ -192,6 +198,7 @@ public sealed partial class Database
 
     private void RaiseDatabaseChanged()
     {
+        Revision++;
         if (_deferredEventCount == 0)
         {
             LastModifiedDate = DateTime.UtcNow;

--- a/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
+++ b/src/Meziantou.Moneiz/Services/DatabaseProvider.cs
@@ -119,11 +119,11 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
     public async Task ExportToFile()
     {
         var database = await GetDatabase();
+        var revision = database.Revision;
         var bytes = database.Export();
 
         await GlobalInterop.ExportToFile(MoneizDownloadFileName, bytes);
-        await GlobalInterop.SetValue(MoneizLocalStorageChangedName, value: false);
-        RaiseDatabaseSaved();
+        await MarkAsSynchronized(database, revision);
     }
 
     public async Task Import(Database database)
@@ -182,6 +182,7 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
     public async Task ExportToGitHub()
     {
         var database = await GetDatabase();
+        var revision = database.Revision;
         var bytes = database.Export();
 
         var configuration = await LoadConfiguration();
@@ -225,9 +226,34 @@ public sealed partial class DatabaseProvider(NavigationManager navigationManager
         configuration.GitHubSha = file?.Sha;
         await SetConfiguration(configuration);
 
-        await GlobalInterop.SetValue(MoneizLocalStorageChangedName, value: false);
+        await MarkAsSynchronized(database, revision);
+    }
+
+    /// <summary>
+    /// Clears the indicator of local changes, unless the database was modified after the exported snapshot was created.
+    /// </summary>
+    private async Task MarkAsSynchronized(Database database, int revision)
+    {
+        if (IsSnapshotUpToDate(database, revision))
+        {
+            await GlobalInterop.SetValue(MoneizLocalStorageChangedName, value: false);
+
+            // The database may have been modified while the value was written, so the indicator must be restored
+            if (!IsSnapshotUpToDate(database, revision))
+            {
+                Console.WriteLine("Database was modified while clearing the local changes indicator => restore it");
+                await GlobalInterop.SetValue(MoneizLocalStorageChangedName, value: true);
+            }
+        }
+        else
+        {
+            Console.WriteLine("Database was modified while exporting => keep the local changes indicator");
+        }
+
         RaiseDatabaseSaved();
     }
+
+    private bool IsSnapshotUpToDate(Database database, int revision) => ReferenceEquals(_database, database) && database.Revision == revision;
 
     public async Task<bool> HasNewVersionOnGitHub()
     {

--- a/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
+++ b/tests/Meziantou.Moneiz.CoreTests/DatabaseTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.IO.Compression;
+using System.Text.Json;
 using Meziantou.Moneiz.Core;
 
 namespace Meziantou.Moneiz.CoreTests;
@@ -344,5 +345,52 @@ public class DatabaseTests
         var labels = db.GetAllLabels().ToList();
 
         Assert.Equal((IEnumerable<string>)["alpha", "beta", "gamma"], labels);
+    }
+
+    [Fact]
+    public void Revision_IsIncrementedOnEveryModification()
+    {
+        var database = new Database();
+        var initialRevision = database.Revision;
+
+        database.SaveAccount(new Account { Name = "Account 1" });
+        var revisionAfterFirstChange = database.Revision;
+
+        database.SaveAccount(new Account { Name = "Account 2" });
+
+        Assert.True(revisionAfterFirstChange > initialRevision);
+        Assert.True(database.Revision > revisionAfterFirstChange);
+    }
+
+    [Fact]
+    public void Revision_IsIncrementedWhenEventsAreDeferred()
+    {
+        var database = new Database();
+        var account = new Account { Name = "Account 1" };
+        database.SaveAccount(account);
+        var revision = database.Revision;
+
+        // SaveTransaction defers the DatabaseChanged event
+        database.SaveTransaction(new Transaction { Account = account, Amount = 1, ValueDate = Database.GetToday() });
+
+        Assert.True(database.Revision > revision);
+    }
+
+    [Fact]
+    public void Revision_IsNotPersisted()
+    {
+        var database = new Database();
+        database.SaveAccount(new Account { Name = "Account 1" });
+        var revision = database.Revision;
+
+        var bytes = database.Export();
+
+        Assert.Equal(revision, database.Revision);
+
+        using var stream = new MemoryStream(bytes);
+        Assert.Equal(2, stream.ReadByte());
+        using var compressedStream = new GZipStream(stream, CompressionMode.Decompress);
+        using var reader = new StreamReader(compressedStream);
+        Assert.DoesNotContain(nameof(Database.Revision), reader.ReadToEnd());
     }
 }


### PR DESCRIPTION
## What

`ExportToGitHub` snapshots the database with `Export()`, then performs several awaited network requests (get user, list repository contents, PUT the file) before unconditionally clearing the `moneiz.dbchanged` indicator. The UI lets the user save transactions while that upload is pending.

**Trigger:** start an export, then save another edit before the upload completes. The edit is not in the uploaded snapshot, but the export completion clears its "Export database" warning and marks the local database as synchronized — the change is silently lost on the next import.

`ExportToFile` has the same shape (snapshot → `await` → unconditional clear), with a shorter window.

## How

- `Database` exposes a new `Revision` counter, incremented in `RaiseDatabaseChanged()` before the deferred-events branch, so modifications made inside a `DeferEvents()` scope count too. It is `[JsonIgnore]`, so the persisted database format is unchanged.
- `ExportToGitHub` and `ExportToFile` capture `database.Revision` next to the `Export()` snapshot and finish through a new `MarkAsSynchronized(database, revision)`.
- `MarkAsSynchronized` clears the indicator only when `IsSnapshotUpToDate` holds: the same `Database` instance **and** the same revision. The instance check matters because `Import` swaps `_database` mid-flight, and revision numbers are per-instance.
- The check is repeated after the awaited storage write: a concurrent `Save()` can write `true` between the two awaits, and would otherwise be clobbered. If that happens, the indicator is restored.
- `RaiseDatabaseSaved()` still fires on every path, so the `DatabaseNotExported` banner re-reads the flag and drops its "Exporting..." state.

## Notes for the reviewer

- Three tests added to `DatabaseTests`: the revision increments on every modification, it increments for mutations that defer events (`SaveTransaction`), and it is neither persisted nor changed by `Export()`.
- `Meziantou.Moneiz.Core`, `Meziantou.Moneiz.CoreTests` and `Meziantou.Moneiz.Cli` build clean; all 24 tests pass.
- **The Blazor WASM project was not built locally**: it requires the `wasm-tools` workload, which is not installed and cannot be installed without elevation in this environment. As a substitute, the modified `DatabaseProvider.cs` was compiled in a scratch `net10.0` project against the real `Meziantou.Moneiz.Core` assembly and the real `Microsoft.AspNetCore.Components.WebAssembly` / `Meziantou.*` packages, with only `GlobalInterop` replaced by a signature-identical stub (its `[JSImport]` partials need the browser TFM) — 0 errors, 0 warnings. That covers the compiler but not the analyzers the Meziantou SDK layers on that project, so CI is the real check there.
