### PR TITLE
Bump CLI package version to 2.0.0 so the subcommand-based CLI actually ships

### DIFF
--- a/src/Meziantou.Moneiz.Cli/Meziantou.Moneiz.Cli.csproj
+++ b/src/Meziantou.Moneiz.Cli/Meziantou.Moneiz.Cli.csproj
@@ -3,7 +3,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>meziantou.moneiz</ToolCommandName>
-    <Version>1.0.3</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## What changed

Bumps `<Version>` in `src/Meziantou.Moneiz.Cli/Meziantou.Moneiz.Cli.csproj` from `1.0.3` to `2.0.0`.

## Why

The `moneiz-db` overdraft check has been failing with:

```
Unrecognized command or argument 'check-overdraft'.
```

The CLI source is fine — the bug is that the fix was never published.

- #80 (Jan 17, 2026) restructured the CLI from a single root command into subcommands (`check-overdraft`, `add-transaction`, `update-transaction`, `get-transactions`). That is the breaking change.
- #267 correctly updated the reusable `check-overdraft.yml` workflow to call `meziantou.moneiz check-overdraft --file …`.
- But `<Version>` has been `1.0.3` since "Bump version" (Dec 30, 2025), i.e. *before* the refactor.

Since `publish.yml` pushes with `dotnet nuget push --skip-duplicate`, every push to `main` since January has succeeded while publishing nothing. nuget.org only has `1.0.0`–`1.0.3`.

I confirmed this by unpacking the published `1.0.3` from nuget.org: its assembly is dated Dec 31, 2025 and contains none of the subcommand names. So `dotnet tool update --global Meziantou.Moneiz.Cli` installs the pre-refactor CLI, which has no `check-overdraft` command — exactly the CI error.

`2.0.0` rather than `1.1.0` because the invocation surface changed incompatibly.

## Verification

- CLI project and test project build clean, 0 warnings.
- 37/37 core tests pass.
- Packed `2.0.0`, installed it as a real tool, and ran both command shapes the workflow uses against a generated database:
  - `check-overdraft --file <db>` → exit `0` when healthy, exit `1` when an overdraft is projected.
  - `check-overdraft --file <db> --account-id "1"` → same.

## Notes for the reviewer

- The `moneiz-db` job stays red until this merges and `publish-cli` pushes `2.0.0` to nuget.org.
- Local `dotnet test` reports "Zero tests ran" (exit 5). That is a pre-existing runner quirk unrelated to this change; running `tests/Meziantou.Moneiz.CoreTests/bin/Debug/net10.0/Meziantou.Moneiz.CoreTests` directly runs all 37.
- **Not addressed here:** the version is hand-maintained, and `--skip-duplicate` makes a missed bump look like a successful release — which is why this went unnoticed for ~8 months. Worth a follow-up: either derive the patch from `GITHUB_RUN_NUMBER` so every main push publishes, or add a CI step that fails when `src/Meziantou.Moneiz.Cli/` changed without a version bump. I left the release semantics alone rather than changing them unasked.
